### PR TITLE
Rework fixes: zigzag path, flashcard, course cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.*
 # generated native folders
 /ios
 /android
+.superpowers/
+.claude/

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,22 +2,34 @@ import { View, Text, StyleSheet, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { colors } from "../../lib/theme";
 import { getCurrentTier } from "../../lib/xpUtils";
+import { useAuthStore } from "../../store/useAuthStore";
 import { useXpStore } from "../../store/useXpStore";
 import { useXpAnimation } from "../../hooks/useXpAnimation";
 import { XpProgressBar } from "../../components/XpProgressBar";
 import { XpAnimatedCounter } from "../../components/XpAnimatedCounter";
 import { RankBadge } from "../../components/RankBadge";
+import { ProfileAvatar } from "../../components/ProfileAvatar";
+import { StreakCard } from "../../components/StreakCard";
+import { LeaderboardList } from "../../components/LeaderboardList";
 
 export default function ProfileScreen() {
+  const user = useAuthStore((s) => s.user);
   const xpTotal = useXpStore((s) => s.xpTotal);
   const tier = getCurrentTier(xpTotal);
   const { animatedXp, displayXp } = useXpAnimation();
 
+  const username = user?.username ?? "DemoStudent";
+
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView contentContainerStyle={styles.content}>
+        {/* Avatar */}
+        <View style={styles.avatarContainer}>
+          <ProfileAvatar size={80} />
+        </View>
+
         {/* Username */}
-        <Text style={styles.username}>DemoStudent</Text>
+        <Text style={styles.username}>{username}</Text>
         <Text style={styles.university}>McGill University</Text>
 
         {/* Shield badge */}
@@ -38,9 +50,14 @@ export default function ProfileScreen() {
         {/* Divider */}
         <View style={styles.divider} />
 
-        {/* Placeholder for leaderboard/stats — issue #5 */}
-        <View style={styles.placeholder}>
-          <Text style={styles.placeholderText}>Leaderboard & Stats (Issue #5)</Text>
+        {/* Streak Card */}
+        <View style={styles.streakContainer}>
+          <StreakCard />
+        </View>
+
+        {/* Leaderboard */}
+        <View style={styles.leaderboardContainer}>
+          <LeaderboardList currentUsername={username} />
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -55,12 +72,16 @@ const styles = StyleSheet.create({
   content: {
     paddingBottom: 48,
   },
+  avatarContainer: {
+    alignItems: "center",
+    marginTop: 24,
+  },
   username: {
     color: colors.text1,
     fontWeight: "800",
     fontSize: 22,
     textAlign: "center",
-    marginTop: 24,
+    marginTop: 10,
     marginBottom: 4,
   },
   university: {
@@ -85,13 +106,12 @@ const styles = StyleSheet.create({
     marginHorizontal: 20,
     marginTop: 16,
   },
-  placeholder: {
-    alignItems: "center",
-    justifyContent: "center",
-    height: 100,
+  streakContainer: {
+    marginTop: 16,
+    marginHorizontal: 20,
   },
-  placeholderText: {
-    color: colors.text3,
-    fontSize: 14,
+  leaderboardContainer: {
+    marginTop: 16,
+    paddingHorizontal: 20,
   },
 });

--- a/app/(tabs)/study.tsx
+++ b/app/(tabs)/study.tsx
@@ -56,6 +56,7 @@ export default function StudyScreen() {
 
   const {
     isStudying, isPaused, elapsedSeconds, mode,
+    deepSecondsLeft, nextBreakIn,
     isOnBreak, breakSecondsLeft,
     startSession, pauseSession, resumeSession, tick,
     startBreak, tickBreak, endBreak,
@@ -331,7 +332,8 @@ export default function StudyScreen() {
           {/* Deep Mode overlay (absoluteFill, renders on top) */}
           {deepPhase === "active" && view === "active" && (
             <DeepModeOverlay
-              elapsedSeconds={elapsedSeconds}
+              deepSecondsLeft={deepSecondsLeft}
+              nextBreakIn={nextBreakIn}
               isOnBreak={isOnBreak}
               breakSecondsLeft={breakSecondsLeft}
             />

--- a/app/(tabs)/study.tsx
+++ b/app/(tabs)/study.tsx
@@ -18,6 +18,9 @@ import {
   getExamCountdown,
   type QuizQuestion,
 } from "../../lib/questionBank";
+import DeepModeTransition from "../../components/DeepModeTransition";
+import DeepModeOverlay from "../../components/DeepModeOverlay";
+import ExitGateModal from "../../components/ExitGateModal";
 
 const MOCK_TOPICS = [
   { id: "t1", name: "Linear Regression", course: "COMP 551" },
@@ -39,6 +42,10 @@ export default function StudyScreen() {
   const [summaryXp, setSummaryXp] = useState(0);
   const [summaryDuration, setSummaryDuration] = useState(0);
 
+  // --- Deep Mode state ---
+  const [deepPhase, setDeepPhase] = useState<null | "transition" | "active">(null);
+  const [exitGateVisible, setExitGateVisible] = useState(false);
+
   // --- Quiz state ---
   const [quizVisible, setQuizVisible] = useState(false);
   const [quizPhase, setQuizPhase] = useState<"question" | "correct" | "wrong">("question");
@@ -47,8 +54,12 @@ export default function StudyScreen() {
   const xpToastScale = useRef(new Animated.Value(0.5)).current;
   const answerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { isStudying, isPaused, elapsedSeconds, startSession, pauseSession, resumeSession, tick } =
-    useStudyStore();
+  const {
+    isStudying, isPaused, elapsedSeconds, mode,
+    isOnBreak, breakSecondsLeft,
+    startSession, pauseSession, resumeSession, tick,
+    startBreak, tickBreak, endBreak,
+  } = useStudyStore();
 
   useEffect(() => {
     if (!isStudying || isPaused) return;
@@ -68,14 +79,45 @@ export default function StudyScreen() {
     }
   }, [quizPhase]);
 
+  // --- Break timer (Deep Mode) ---
+  useEffect(() => {
+    if (!isOnBreak) return;
+    const id = setInterval(() => tickBreak(), 1000);
+    return () => clearInterval(id);
+  }, [isOnBreak, tickBreak]);
+
+  // When break ends naturally, resume session
+  useEffect(() => {
+    if (!isOnBreak && breakSecondsLeft === 0 && isStudying && isPaused && mode === "deep") {
+      endBreak();
+    }
+  }, [isOnBreak, breakSecondsLeft, isStudying, isPaused, mode, endBreak]);
+
   function handleStartSession() {
+    if (selectedMode === "deep") {
+      setDeepPhase("transition");
+      setView("active");
+      return;
+    }
     startSession(selectedMode, selectedTopicId);
     setView("active");
   }
 
+  function handleTransitionComplete() {
+    setDeepPhase("active");
+    startSession("deep", selectedTopicId);
+  }
+
   async function handleEndSession() {
-    const { elapsedSeconds: elapsed, endSession, currentTopicId, mode } =
+    const { elapsedSeconds: elapsed, endSession, currentTopicId, mode: currentMode } =
       useStudyStore.getState();
+
+    // Deep Mode: show exit gate instead of ending directly
+    if (currentMode === "deep") {
+      setExitGateVisible(true);
+      return;
+    }
+
     const userId = useAuthStore.getState().user?.id ?? "mock-user-id";
     endSession();
 
@@ -87,7 +129,7 @@ export default function StudyScreen() {
         body: {
           userId,
           topicId: currentTopicId ?? "unknown",
-          mode: mode ?? "focus",
+          mode: currentMode ?? "focus",
           durationSeconds: elapsed,
         },
       }) ?? {};
@@ -106,9 +148,56 @@ export default function StudyScreen() {
 
   function handleDismissSummary() {
     useStudyStore.getState().resetSession();
+    setDeepPhase(null);
     setView("setup");
     setSummaryXp(0);
     setSummaryDuration(0);
+  }
+
+  // --- Exit Gate handlers (Deep Mode) ---
+  function handleExitStay() {
+    setExitGateVisible(false);
+    resumeSession();
+  }
+
+  function handleExitQuizCorrect() {
+    setExitGateVisible(false);
+    startBreak();
+  }
+
+  async function handleExitPenalty() {
+    setExitGateVisible(false);
+    useXpStore.getState().addXp(-20);
+
+    const { elapsedSeconds: elapsed, endSession, currentTopicId } =
+      useStudyStore.getState();
+    const userId = useAuthStore.getState().user?.id ?? "mock-user-id";
+    endSession();
+
+    setSummaryDuration(elapsed);
+    setDeepPhase(null);
+    setView("summary");
+
+    try {
+      const { data, error } = await supabase?.functions.invoke("award_xp", {
+        body: {
+          userId,
+          topicId: currentTopicId ?? "unknown",
+          mode: "deep",
+          durationSeconds: elapsed,
+        },
+      }) ?? {};
+
+      const xpEarned = data?.xpEarned ?? 0;
+      setSummaryXp(xpEarned);
+      if (data?.newXpTotal != null) {
+        useXpStore.getState().setXp(data.newXpTotal);
+      }
+      if (error) console.warn("award_xp error:", error);
+    } catch (err) {
+      console.warn("award_xp call failed (expected in dev):", err);
+      setSummaryXp(0);
+    }
   }
 
   function handleOpenQuiz() {
@@ -205,8 +294,13 @@ export default function StudyScreen() {
         </ScrollView>
       )}
 
+      {/* ── DEEP MODE TRANSITION ── */}
+      {view === "active" && deepPhase === "transition" && (
+        <DeepModeTransition onComplete={handleTransitionComplete} />
+      )}
+
       {/* ── ACTIVE TIMER VIEW ── */}
-      {(view === "active" || view === "summary") && (
+      {(view === "active" || view === "summary") && deepPhase !== "transition" && (
         <View style={styles.activeContent}>
           <Text style={styles.modeLabel}>
             {selectedMode.toUpperCase()} MODE
@@ -232,6 +326,15 @@ export default function StudyScreen() {
             <TouchableOpacity style={styles.quizCheckpointButton} onPress={handleOpenQuiz}>
               <Text style={styles.quizCheckpointButtonText}>Quiz Checkpoint</Text>
             </TouchableOpacity>
+          )}
+
+          {/* Deep Mode overlay (absoluteFill, renders on top) */}
+          {deepPhase === "active" && view === "active" && (
+            <DeepModeOverlay
+              elapsedSeconds={elapsedSeconds}
+              isOnBreak={isOnBreak}
+              breakSecondsLeft={breakSecondsLeft}
+            />
           )}
         </View>
       )}
@@ -339,6 +442,16 @@ export default function StudyScreen() {
           </View>
         </View>
       </Modal>
+
+      {/* ── EXIT GATE MODAL (Deep Mode) ── */}
+      <ExitGateModal
+        visible={exitGateVisible}
+        topicId={useStudyStore.getState().currentTopicId ?? "unknown"}
+        daysUntilExam={null}
+        onStay={handleExitStay}
+        onQuizCorrect={handleExitQuizCorrect}
+        onPenaltyExit={handleExitPenalty}
+      />
     </SafeAreaView>
   );
 }

--- a/components/CourseCard.tsx
+++ b/components/CourseCard.tsx
@@ -18,14 +18,12 @@ export default function CourseCard({ course }: CourseCardProps) {
     course.topics.find((t) => t.status === "locked");
   const currentTopicLabel = currentTopic ? currentTopic.name : "All complete";
 
-  // Nearest undefeated exam
-  const undefeatedExams = course.exams.filter((e) => !e.defeated);
-  let nearestExam: (typeof undefeatedExams)[number] | null = null;
-  let daysUntilExam = 0;
-  // Filter to future undefeated exams only
-  const futureExams = undefeatedExams.filter(
-    (e) => new Date(e.examDate).getTime() > Date.now()
+  // Nearest future undefeated exam
+  const futureExams = course.exams.filter(
+    (e) => !e.defeated && new Date(e.examDate).getTime() > Date.now()
   );
+  let nearestExam: (typeof futureExams)[number] | null = null;
+  let daysUntilExam = 0;
   if (futureExams.length > 0) {
     nearestExam = futureExams.reduce((closest, exam) => {
       const d = new Date(exam.examDate).getTime() - Date.now();
@@ -63,15 +61,14 @@ export default function CourseCard({ course }: CourseCardProps) {
         <View style={styles.mainContent}>
           {/* Header row */}
           <View style={styles.headerRow}>
-            <View style={styles.headerText}>
+            <View style={styles.headerLeft}>
               <Text style={styles.courseName}>{course.name}</Text>
-              <Text style={styles.courseCode}>{course.code}</Text>
               <Text style={styles.currentTopic}>
                 Currently: {currentTopicLabel}
               </Text>
             </View>
 
-            {/* Exam badge */}
+            {/* Exam badge — pinned far right */}
             {nearestExam != null && (
               <View
                 style={[
@@ -86,7 +83,7 @@ export default function CourseCard({ course }: CourseCardProps) {
                 <Text
                   style={[
                     styles.examBadgeText,
-                    { color: isUrgent ? "#FF5757" : "#B99BFF" },
+                    { color: isUrgent ? colors.danger : colors.primaryLight },
                   ]}
                 >
                   {daysUntilExam} {daysUntilExam === 1 ? "day" : "days"}
@@ -174,18 +171,14 @@ const styles = StyleSheet.create({
     alignItems: "flex-start",
     marginBottom: 12,
   },
-  headerText: {
+  headerLeft: {
     flex: 1,
+    marginRight: 8,
   },
   courseName: {
     fontSize: 16,
     fontWeight: "700",
     color: colors.text1,
-  },
-  courseCode: {
-    fontSize: 12,
-    color: colors.text3,
-    marginTop: 2,
   },
   currentTopic: {
     fontSize: 12,
@@ -194,10 +187,10 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   examBadge: {
-    paddingHorizontal: 8,
+    paddingHorizontal: 10,
     paddingVertical: 4,
-    borderRadius: radii.sm,
-    marginLeft: 8,
+    borderRadius: 12,
+    flexShrink: 0,
   },
   examBadgeText: {
     fontSize: 11,

--- a/components/DeepModeOverlay.tsx
+++ b/components/DeepModeOverlay.tsx
@@ -4,19 +4,25 @@ import { Ionicons } from "@expo/vector-icons";
 import { colors } from "../lib/theme";
 
 interface DeepModeOverlayProps {
-  elapsedSeconds: number;
+  deepSecondsLeft: number;
+  nextBreakIn: number;
   isOnBreak: boolean;
   breakSecondsLeft: number;
 }
 
 function formatTime(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
+  const hrs = Math.floor(seconds / 3600);
+  const mins = Math.floor((seconds % 3600) / 60);
   const secs = seconds % 60;
+  if (hrs > 0) {
+    return `${hrs}:${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+  }
   return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
 }
 
 export default function DeepModeOverlay({
-  elapsedSeconds,
+  deepSecondsLeft,
+  nextBreakIn,
   isOnBreak,
   breakSecondsLeft,
 }: DeepModeOverlayProps) {
@@ -25,16 +31,8 @@ export default function DeepModeOverlay({
   useEffect(() => {
     const loop = Animated.loop(
       Animated.sequence([
-        Animated.timing(glowAnim, {
-          toValue: 20,
-          duration: 1000,
-          useNativeDriver: false,
-        }),
-        Animated.timing(glowAnim, {
-          toValue: 8,
-          duration: 1000,
-          useNativeDriver: false,
-        }),
+        Animated.timing(glowAnim, { toValue: 20, duration: 1000, useNativeDriver: false }),
+        Animated.timing(glowAnim, { toValue: 8, duration: 1000, useNativeDriver: false }),
       ])
     );
     loop.start();
@@ -51,27 +49,30 @@ export default function DeepModeOverlay({
 
       {/* Header */}
       <View style={styles.header}>
-        <Ionicons name="lock-closed" size={16} color="#B99BFF" />
+        <Ionicons name="lock-closed" size={16} color={colors.primaryLight} />
         <Text style={styles.headerText}>DEEP MODE</Text>
       </View>
 
-      {/* Timer */}
+      {/* Main countdown timer — 2:30:00 */}
       <Animated.Text
         style={[
-          styles.timer,
-          {
-            shadowRadius: glowAnim,
-          },
+          styles.mainTimer,
+          { shadowRadius: glowAnim },
         ]}
       >
-        {formatTime(elapsedSeconds)}
+        {formatTime(deepSecondsLeft)}
       </Animated.Text>
 
-      {/* Break timer */}
-      {isOnBreak && (
-        <View style={styles.breakContainer}>
+      {/* Break / Next break timer */}
+      {isOnBreak ? (
+        <View style={styles.subTimerWrap}>
           <Text style={styles.breakLabel}>BREAK</Text>
-          <Text style={styles.breakTime}>{formatTime(breakSecondsLeft)}</Text>
+          <Text style={styles.breakTimer}>{formatTime(breakSecondsLeft)}</Text>
+        </View>
+      ) : (
+        <View style={styles.subTimerWrap}>
+          <Text style={styles.nextBreakLabel}>NEXT BREAK IN</Text>
+          <Text style={styles.nextBreakTimer}>{formatTime(nextBreakIn)}</Text>
         </View>
       )}
     </View>
@@ -86,33 +87,25 @@ const styles = StyleSheet.create({
   },
   vignetteTop: {
     position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
+    top: 0, left: 0, right: 0,
     height: 120,
     backgroundColor: "rgba(0,0,0,0.6)",
   },
   vignetteBottom: {
     position: "absolute",
-    bottom: 0,
-    left: 0,
-    right: 0,
+    bottom: 0, left: 0, right: 0,
     height: 120,
     backgroundColor: "rgba(0,0,0,0.6)",
   },
   vignetteLeft: {
     position: "absolute",
-    top: 0,
-    bottom: 0,
-    left: 0,
+    top: 0, bottom: 0, left: 0,
     width: 40,
     backgroundColor: "rgba(0,0,0,0.4)",
   },
   vignetteRight: {
     position: "absolute",
-    top: 0,
-    bottom: 0,
-    right: 0,
+    top: 0, bottom: 0, right: 0,
     width: 40,
     backgroundColor: "rgba(0,0,0,0.4)",
   },
@@ -126,31 +119,45 @@ const styles = StyleSheet.create({
   },
   headerText: {
     fontSize: 13,
-    color: "#B99BFF",
+    color: colors.primaryLight,
     fontWeight: "700",
     letterSpacing: 1.5,
   },
-  timer: {
-    fontSize: 72,
+  mainTimer: {
+    fontSize: 64,
     fontWeight: "800",
     color: colors.text1,
-    shadowColor: "#9B6DFF",
+    letterSpacing: -2,
+    shadowColor: colors.primary,
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 1,
   },
-  breakContainer: {
+  subTimerWrap: {
     alignItems: "center",
-    marginTop: 12,
+    marginTop: 20,
   },
   breakLabel: {
     fontSize: 11,
-    color: "#F5C842",
     fontWeight: "700",
+    color: colors.gold,
     letterSpacing: 1.5,
   },
-  breakTime: {
+  breakTimer: {
     fontSize: 28,
-    color: "#F5C842",
     fontWeight: "700",
+    color: colors.gold,
+    marginTop: 4,
+  },
+  nextBreakLabel: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: colors.text3,
+    letterSpacing: 1,
+  },
+  nextBreakTimer: {
+    fontSize: 22,
+    fontWeight: "600",
+    color: colors.text2,
+    marginTop: 4,
   },
 });

--- a/components/DeepModeOverlay.tsx
+++ b/components/DeepModeOverlay.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useRef } from "react";
+import { View, Text, StyleSheet, Animated } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { colors } from "../lib/theme";
+
+interface DeepModeOverlayProps {
+  elapsedSeconds: number;
+  isOnBreak: boolean;
+  breakSecondsLeft: number;
+}
+
+function formatTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+}
+
+export default function DeepModeOverlay({
+  elapsedSeconds,
+  isOnBreak,
+  breakSecondsLeft,
+}: DeepModeOverlayProps) {
+  const glowAnim = useRef(new Animated.Value(8)).current;
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(glowAnim, {
+          toValue: 20,
+          duration: 1000,
+          useNativeDriver: false,
+        }),
+        Animated.timing(glowAnim, {
+          toValue: 8,
+          duration: 1000,
+          useNativeDriver: false,
+        }),
+      ])
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [glowAnim]);
+
+  return (
+    <View style={styles.container} pointerEvents="none">
+      {/* Vignette bars */}
+      <View style={styles.vignetteTop} />
+      <View style={styles.vignetteBottom} />
+      <View style={styles.vignetteLeft} />
+      <View style={styles.vignetteRight} />
+
+      {/* Header */}
+      <View style={styles.header}>
+        <Ionicons name="lock-closed" size={16} color="#B99BFF" />
+        <Text style={styles.headerText}>DEEP MODE</Text>
+      </View>
+
+      {/* Timer */}
+      <Animated.Text
+        style={[
+          styles.timer,
+          {
+            shadowRadius: glowAnim,
+          },
+        ]}
+      >
+        {formatTime(elapsedSeconds)}
+      </Animated.Text>
+
+      {/* Break timer */}
+      {isOnBreak && (
+        <View style={styles.breakContainer}>
+          <Text style={styles.breakLabel}>BREAK</Text>
+          <Text style={styles.breakTime}>{formatTime(breakSecondsLeft)}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  vignetteTop: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 120,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  vignetteBottom: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 120,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  vignetteLeft: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: 40,
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  vignetteRight: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    right: 0,
+    width: 40,
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  header: {
+    position: "absolute",
+    top: 60,
+    alignSelf: "center",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  headerText: {
+    fontSize: 13,
+    color: "#B99BFF",
+    fontWeight: "700",
+    letterSpacing: 1.5,
+  },
+  timer: {
+    fontSize: 72,
+    fontWeight: "800",
+    color: colors.text1,
+    shadowColor: "#9B6DFF",
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 1,
+  },
+  breakContainer: {
+    alignItems: "center",
+    marginTop: 12,
+  },
+  breakLabel: {
+    fontSize: 11,
+    color: "#F5C842",
+    fontWeight: "700",
+    letterSpacing: 1.5,
+  },
+  breakTime: {
+    fontSize: 28,
+    color: "#F5C842",
+    fontWeight: "700",
+  },
+});

--- a/components/DeepModeTransition.tsx
+++ b/components/DeepModeTransition.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Video, ResizeMode } from "expo-av";
+import { colors } from "../lib/theme";
+
+interface Props {
+  onComplete: () => void;
+}
+
+export default function DeepModeTransition({ onComplete }: Props) {
+  const bubbleTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const advanceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [showBubble, setShowBubble] = useState(false);
+
+  useEffect(() => {
+    bubbleTimeout.current = setTimeout(() => {
+      setShowBubble(true);
+    }, 400);
+
+    advanceTimeout.current = setTimeout(() => {
+      onComplete();
+    }, 3000);
+
+    return () => {
+      if (bubbleTimeout.current) clearTimeout(bubbleTimeout.current);
+      if (advanceTimeout.current) clearTimeout(advanceTimeout.current);
+    };
+  }, [onComplete]);
+
+  return (
+    <View style={styles.container}>
+      {showBubble && (
+        <View style={styles.bubbleWrapper}>
+          <View style={styles.bubble}>
+            <Text style={styles.bubbleText}>Lock in</Text>
+          </View>
+          <View style={styles.spikeRow}>
+            <View style={styles.spikeOuter} />
+            <View style={styles.spikeInner} />
+          </View>
+        </View>
+      )}
+
+      <Video
+        source={require("../assets/crack-deep-mode.mp4")}
+        style={styles.video}
+        resizeMode={ResizeMode.CONTAIN}
+        shouldPlay
+        isLooping={false}
+        isMuted
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#000000",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  bubbleWrapper: {
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  bubble: {
+    backgroundColor: colors.surface2,
+    borderRadius: 16,
+    borderWidth: 1.5,
+    borderColor: colors.primary,
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+  },
+  spikeRow: {
+    alignSelf: "center",
+    position: "relative",
+  },
+  spikeOuter: {
+    width: 0,
+    height: 0,
+    borderLeftWidth: 10,
+    borderRightWidth: 10,
+    borderTopWidth: 14,
+    borderLeftColor: "transparent",
+    borderRightColor: "transparent",
+    borderTopColor: colors.primary,
+  },
+  spikeInner: {
+    position: "absolute",
+    top: -1.5,
+    left: 1.5,
+    width: 0,
+    height: 0,
+    borderLeftWidth: 8.5,
+    borderRightWidth: 8.5,
+    borderTopWidth: 12.5,
+    borderLeftColor: "transparent",
+    borderRightColor: "transparent",
+    borderTopColor: colors.surface2,
+  },
+  bubbleText: {
+    color: colors.text1,
+    fontSize: 15,
+    fontWeight: "600",
+    lineHeight: 22,
+    textAlign: "center",
+  },
+  video: {
+    width: 280,
+    height: 280,
+  },
+});

--- a/components/DeepModeTransition.tsx
+++ b/components/DeepModeTransition.tsx
@@ -1,34 +1,52 @@
 import { useEffect, useRef, useState } from "react";
-import { View, Text, StyleSheet } from "react-native";
-import { Video, ResizeMode } from "expo-av";
+import { View, Text, Image, StyleSheet } from "react-native";
+import { Video, ResizeMode, AVPlaybackStatus } from "expo-av";
 import { colors } from "../lib/theme";
+
+// Video is 3.04s at 24fps
+const VIDEO_DURATION_MS = 3040;
+const BUBBLE_DELAY_MS = Math.round(VIDEO_DURATION_MS / 4); // 1/4 of video
+const PAUSE_AFTER_VIDEO_MS = 1500; // pause on last frame before advancing
 
 interface Props {
   onComplete: () => void;
 }
 
 export default function DeepModeTransition({ onComplete }: Props) {
+  const [showBubble, setShowBubble] = useState(false);
+  const [videoPlaying, setVideoPlaying] = useState(false);
+  const [videoEnded, setVideoEnded] = useState(false);
   const bubbleTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const advanceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [showBubble, setShowBubble] = useState(false);
+
+  const handlePlaybackStatus = (status: AVPlaybackStatus) => {
+    if (!status.isLoaded) return;
+
+    // Video started playing — swap from image to video
+    if (status.isPlaying && !videoPlaying) {
+      setVideoPlaying(true);
+
+      // Show bubble at 1/4 of video duration
+      bubbleTimeout.current = setTimeout(() => setShowBubble(true), BUBBLE_DELAY_MS);
+    }
+
+    // Video finished — pause on last frame, then advance
+    if (status.didJustFinish && !videoEnded) {
+      setVideoEnded(true);
+      advanceTimeout.current = setTimeout(() => onComplete(), PAUSE_AFTER_VIDEO_MS);
+    }
+  };
 
   useEffect(() => {
-    bubbleTimeout.current = setTimeout(() => {
-      setShowBubble(true);
-    }, 400);
-
-    advanceTimeout.current = setTimeout(() => {
-      onComplete();
-    }, 3000);
-
     return () => {
       if (bubbleTimeout.current) clearTimeout(bubbleTimeout.current);
       if (advanceTimeout.current) clearTimeout(advanceTimeout.current);
     };
-  }, [onComplete]);
+  }, []);
 
   return (
     <View style={styles.container}>
+      {/* Speech bubble */}
       {showBubble && (
         <View style={styles.bubbleWrapper}>
           <View style={styles.bubble}>
@@ -41,13 +59,24 @@ export default function DeepModeTransition({ onComplete }: Props) {
         </View>
       )}
 
+      {/* Static mascot — visible until video starts */}
+      {!videoPlaying && (
+        <Image
+          source={require("../assets/crack-mascot.png")}
+          style={styles.mascot}
+          resizeMode="contain"
+        />
+      )}
+
+      {/* Video — hidden until playing */}
       <Video
         source={require("../assets/crack-deep-mode.mp4")}
-        style={styles.video}
+        style={[styles.video, !videoPlaying && styles.hidden]}
         resizeMode={ResizeMode.CONTAIN}
         shouldPlay
         isLooping={false}
         isMuted
+        onPlaybackStatusUpdate={handlePlaybackStatus}
       />
     </View>
   );
@@ -62,7 +91,8 @@ const styles = StyleSheet.create({
   },
   bubbleWrapper: {
     alignItems: "center",
-    marginBottom: 16,
+    marginBottom: -4,
+    zIndex: 10,
   },
   bubble: {
     backgroundColor: colors.surface2,
@@ -70,7 +100,14 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     borderColor: colors.primary,
     paddingVertical: 14,
-    paddingHorizontal: 20,
+    paddingHorizontal: 28,
+  },
+  bubbleText: {
+    color: colors.text1,
+    fontSize: 22,
+    fontWeight: "800",
+    letterSpacing: 0.5,
+    textAlign: "center",
   },
   spikeRow: {
     alignSelf: "center",
@@ -99,15 +136,16 @@ const styles = StyleSheet.create({
     borderRightColor: "transparent",
     borderTopColor: colors.surface2,
   },
-  bubbleText: {
-    color: colors.text1,
-    fontSize: 15,
-    fontWeight: "600",
-    lineHeight: 22,
-    textAlign: "center",
+  mascot: {
+    width: 280,
+    height: 280,
   },
   video: {
     width: 280,
     height: 280,
+    position: "absolute",
+  },
+  hidden: {
+    opacity: 0,
   },
 });

--- a/components/ExitGateModal.tsx
+++ b/components/ExitGateModal.tsx
@@ -1,0 +1,356 @@
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+} from "react-native";
+import { colors, radii } from "../lib/theme";
+import { QUESTION_BANK, QuizQuestion } from "../lib/questionBank";
+
+interface ExitGateModalProps {
+  visible: boolean;
+  topicId: string;
+  daysUntilExam: number | null;
+  onStay: () => void;
+  onQuizCorrect: () => void;
+  onPenaltyExit: () => void;
+}
+
+type Phase = "choose" | "quiz" | "wrong";
+
+function pickRandomQuestion(topicId: string): QuizQuestion | null {
+  const pool = QUESTION_BANK.filter((q) => q.topicId === topicId);
+  if (pool.length === 0) return null;
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+export default function ExitGateModal({
+  visible,
+  topicId,
+  daysUntilExam,
+  onStay,
+  onQuizCorrect,
+  onPenaltyExit,
+}: ExitGateModalProps) {
+  const [phase, setPhase] = useState<Phase>("choose");
+  const [question, setQuestion] = useState<QuizQuestion | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [answerResult, setAnswerResult] = useState<"correct" | "wrong" | null>(
+    null
+  );
+
+  const reset = useCallback(() => {
+    setPhase("choose");
+    setQuestion(null);
+    setSelectedIndex(null);
+    setAnswerResult(null);
+  }, []);
+
+  // Reset when modal opens or when onStay resets externally
+  useEffect(() => {
+    if (visible) {
+      reset();
+    }
+  }, [visible, reset]);
+
+  const loadQuestion = useCallback(() => {
+    setQuestion(pickRandomQuestion(topicId));
+    setSelectedIndex(null);
+    setAnswerResult(null);
+  }, [topicId]);
+
+  const handleAnswerQuestion = () => {
+    loadQuestion();
+    setPhase("quiz");
+  };
+
+  const handleStay = () => {
+    reset();
+    onStay();
+  };
+
+  const handleSelectOption = (index: number) => {
+    if (selectedIndex !== null) return; // already selected
+    setSelectedIndex(index);
+
+    const isCorrect = question !== null && index === question.correctIndex;
+    setAnswerResult(isCorrect ? "correct" : "wrong");
+
+    setTimeout(() => {
+      if (isCorrect) {
+        reset();
+        onQuizCorrect();
+      } else {
+        setPhase("wrong");
+        setSelectedIndex(null);
+        setAnswerResult(null);
+      }
+    }, 800);
+  };
+
+  const handleTryAnother = () => {
+    loadQuestion();
+    setPhase("quiz");
+  };
+
+  // Build exam countdown text
+  const examText =
+    daysUntilExam !== null
+      ? ` Your midterm is in ${daysUntilExam} ${daysUntilExam === 1 ? "day" : "days"}.`
+      : "";
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={handleStay}
+    >
+      <View style={styles.overlay}>
+        <View style={styles.card}>
+          {/* ── Choose Phase ─────────────────────────────────── */}
+          {phase === "choose" && (
+            <>
+              <Text style={styles.title}>End Deep Mode?</Text>
+              <Text style={styles.body}>
+                {`-20 XP penalty.${examText}`}
+              </Text>
+
+              <TouchableOpacity
+                style={styles.primaryButton}
+                onPress={handleAnswerQuestion}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.primaryButtonText}>
+                  ANSWER A QUESTION INSTEAD
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.secondaryButton}
+                onPress={handleStay}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.secondaryButtonText}>STAY</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.dangerButton}
+                onPress={onPenaltyExit}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.dangerButtonText}>LEAVE (-20 XP)</Text>
+              </TouchableOpacity>
+            </>
+          )}
+
+          {/* ── Quiz Phase ───────────────────────────────────── */}
+          {phase === "quiz" && question && (
+            <>
+              <Text style={styles.quizLabel}>
+                ANSWER CORRECTLY FOR A 5-MIN BREAK
+              </Text>
+              <Text style={styles.questionText}>{question.question}</Text>
+
+              {question.options.map((option, index) => {
+                const isSelected = selectedIndex === index;
+                const isCorrectAnswer = index === question.correctIndex;
+
+                const optionStyles = [styles.optionButton as object];
+                const textStyles = [styles.optionText as object];
+
+                if (answerResult !== null && isSelected) {
+                  if (answerResult === "correct") {
+                    optionStyles.push(styles.optionCorrect);
+                    textStyles.push({ color: colors.success });
+                  } else {
+                    optionStyles.push(styles.optionWrong);
+                    textStyles.push({ color: colors.danger });
+                  }
+                }
+                // Also highlight the correct answer when wrong was picked
+                if (
+                  answerResult === "wrong" &&
+                  !isSelected &&
+                  isCorrectAnswer
+                ) {
+                  optionStyles.push(styles.optionCorrect);
+                }
+
+                return (
+                  <TouchableOpacity
+                    key={index}
+                    style={optionStyles}
+                    onPress={() => handleSelectOption(index)}
+                    activeOpacity={0.8}
+                    disabled={selectedIndex !== null}
+                  >
+                    <Text style={textStyles}>{option}</Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </>
+          )}
+
+          {/* ── Wrong Phase ──────────────────────────────────── */}
+          {phase === "wrong" && (
+            <>
+              <Text style={styles.title}>Not quite!</Text>
+              <Text style={styles.body}>
+                {`Keep going, you've got this!${examText}`}
+              </Text>
+
+              <TouchableOpacity
+                style={styles.primaryButton}
+                onPress={handleTryAnother}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.primaryButtonText}>
+                  TRY ANOTHER QUESTION
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.secondaryButton}
+                onPress={handleStay}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.secondaryButtonText}>
+                  BACK TO STUDYING
+                </Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.dangerButton}
+                onPress={onPenaltyExit}
+                activeOpacity={0.8}
+              >
+                <Text style={styles.dangerButtonText}>LEAVE (-20 XP)</Text>
+              </TouchableOpacity>
+            </>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.8)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.lg,
+    padding: 24,
+    width: "100%",
+  },
+
+  // ── Typography ──────────────────────────────────────────────
+  title: {
+    fontSize: 22,
+    fontWeight: "800",
+    color: colors.text1,
+    textAlign: "center",
+    marginBottom: 12,
+  },
+  body: {
+    fontSize: 14,
+    color: colors.text2,
+    textAlign: "center",
+    marginBottom: 24,
+    lineHeight: 20,
+  },
+
+  // ── Choose / Wrong buttons ──────────────────────────────────
+  primaryButton: {
+    backgroundColor: colors.primary,
+    borderRadius: radii.pill,
+    paddingVertical: 14,
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  primaryButtonText: {
+    color: colors.white,
+    fontWeight: "700",
+    fontSize: 14,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  secondaryButton: {
+    backgroundColor: colors.surface3,
+    borderRadius: radii.pill,
+    paddingVertical: 14,
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  secondaryButtonText: {
+    color: colors.text1,
+    fontWeight: "700",
+    fontSize: 14,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  dangerButton: {
+    borderWidth: 1,
+    borderColor: colors.danger,
+    borderRadius: radii.pill,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  dangerButtonText: {
+    color: colors.danger,
+    fontWeight: "700",
+    fontSize: 14,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+
+  // ── Quiz phase ──────────────────────────────────────────────
+  quizLabel: {
+    fontSize: 11,
+    color: colors.text3,
+    textTransform: "uppercase",
+    textAlign: "center",
+    letterSpacing: 1,
+    marginBottom: 16,
+  },
+  questionText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: colors.text1,
+    textAlign: "center",
+    lineHeight: 24,
+    marginBottom: 20,
+  },
+  optionButton: {
+    backgroundColor: colors.surface3,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radii.md,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    marginBottom: 10,
+  },
+  optionText: {
+    fontSize: 14,
+    color: colors.text1,
+    lineHeight: 20,
+  },
+  optionCorrect: {
+    borderColor: colors.success,
+    backgroundColor: "rgba(78,255,180,0.1)",
+  },
+  optionWrong: {
+    borderColor: colors.danger,
+    backgroundColor: "rgba(255,87,87,0.1)",
+  },
+});

--- a/components/FlashcardModal.tsx
+++ b/components/FlashcardModal.tsx
@@ -75,18 +75,27 @@ export default function FlashcardModal({
 
               <Text style={styles.question}>{question.question}</Text>
 
-              <View style={styles.answerArea}>
-                {!revealed && <Text style={styles.tapHint}>TAP TO REVEAL</Text>}
-                <TouchableOpacity
-                  activeOpacity={0.8}
-                  onPress={() => setRevealed(true)}
-                  disabled={revealed}
-                >
-                  <Text style={[styles.answer, { opacity: revealed ? 1 : 0.15 }]}>
+              <TouchableOpacity
+                style={styles.answerArea}
+                activeOpacity={0.8}
+                onPress={() => setRevealed(true)}
+                disabled={revealed}
+              >
+                {revealed ? (
+                  <Text style={styles.answerRevealed}>
                     {question.options[question.correctIndex]}
                   </Text>
-                </TouchableOpacity>
-              </View>
+                ) : (
+                  <View style={styles.hiddenAnswer}>
+                    <Text style={styles.tapHint}>TAP TO REVEAL</Text>
+                    <View style={styles.hiddenLines}>
+                      <View style={styles.hiddenLine} />
+                      <View style={[styles.hiddenLine, { width: "70%" }]} />
+                      <View style={[styles.hiddenLine, { width: "85%" }]} />
+                    </View>
+                  </View>
+                )}
+              </TouchableOpacity>
             </>
           ) : (
             <View style={styles.emptyState}>
@@ -133,22 +142,43 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: colors.text1,
     fontWeight: "600",
+    lineHeight: 24,
     marginBottom: 24,
   },
   answerArea: {
+    backgroundColor: colors.surface3,
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: colors.border,
     marginBottom: 24,
   },
+  hiddenAnswer: {
+    alignItems: "center",
+  },
   tapHint: {
-    fontSize: 10,
+    fontSize: 11,
     textTransform: "uppercase",
     color: colors.text3,
     letterSpacing: 1,
-    marginBottom: 8,
-  },
-  answer: {
-    fontSize: 16,
-    color: colors.text1,
     fontWeight: "600",
+    marginBottom: 12,
+  },
+  hiddenLines: {
+    width: "100%",
+    gap: 8,
+  },
+  hiddenLine: {
+    height: 8,
+    backgroundColor: colors.border,
+    borderRadius: 4,
+    width: "100%",
+  },
+  answerRevealed: {
+    fontSize: 15,
+    color: colors.success,
+    fontWeight: "600",
+    lineHeight: 22,
   },
   emptyState: {
     alignItems: "center",

--- a/components/LeaderboardList.tsx
+++ b/components/LeaderboardList.tsx
@@ -1,0 +1,68 @@
+import { View, Text, StyleSheet } from "react-native";
+import { colors } from "../lib/theme";
+import { DEMO_LEADERBOARD } from "../lib/mockData";
+import { LeaderboardRow } from "./LeaderboardRow";
+
+interface LeaderboardListProps {
+  currentUsername: string;
+}
+
+export function LeaderboardList({ currentUsername }: LeaderboardListProps) {
+  const sorted = [...DEMO_LEADERBOARD].sort((a, b) => b.xp - a.xp);
+
+  const currentUserEntry = sorted.find(
+    (entry) => entry.username === currentUsername
+  );
+  const currentUserRank = currentUserEntry
+    ? sorted.indexOf(currentUserEntry) + 1
+    : null;
+
+  return (
+    <View>
+      <Text style={styles.sectionLabel}>LEADERBOARD</Text>
+
+      {sorted.map((entry, index) => (
+        <LeaderboardRow
+          key={entry.username}
+          rank={index + 1}
+          username={entry.username}
+          xp={entry.xp}
+          tier={entry.tier}
+          isCurrentUser={entry.username === currentUsername}
+        />
+      ))}
+
+      {currentUserEntry && currentUserRank && (
+        <View style={styles.pinnedContainer}>
+          <LeaderboardRow
+            rank={currentUserRank}
+            username={currentUserEntry.username}
+            xp={currentUserEntry.xp}
+            tier={currentUserEntry.tier}
+            isCurrentUser={true}
+          />
+          <Text style={styles.pinnedLabel}>Your position</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: colors.text3,
+    letterSpacing: 1.5,
+    marginBottom: 10,
+  },
+  pinnedContainer: {
+    marginTop: 8,
+  },
+  pinnedLabel: {
+    fontSize: 10,
+    color: colors.text3,
+    textAlign: "center",
+    marginTop: -2,
+  },
+});

--- a/components/LeaderboardList.tsx
+++ b/components/LeaderboardList.tsx
@@ -1,4 +1,4 @@
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, ScrollView, StyleSheet } from "react-native";
 import { colors } from "../lib/theme";
 import { DEMO_LEADERBOARD } from "../lib/mockData";
 import { LeaderboardRow } from "./LeaderboardRow";
@@ -21,16 +21,18 @@ export function LeaderboardList({ currentUsername }: LeaderboardListProps) {
     <View>
       <Text style={styles.sectionLabel}>LEADERBOARD</Text>
 
-      {sorted.map((entry, index) => (
-        <LeaderboardRow
-          key={entry.username}
-          rank={index + 1}
-          username={entry.username}
-          xp={entry.xp}
-          tier={entry.tier}
-          isCurrentUser={entry.username === currentUsername}
-        />
-      ))}
+      <ScrollView style={styles.scrollArea} nestedScrollEnabled>
+        {sorted.map((entry, index) => (
+          <LeaderboardRow
+            key={entry.username}
+            rank={index + 1}
+            username={entry.username}
+            xp={entry.xp}
+            tier={entry.tier}
+            isCurrentUser={entry.username === currentUsername}
+          />
+        ))}
+      </ScrollView>
 
       {currentUserEntry && currentUserRank && (
         <View style={styles.pinnedContainer}>
@@ -55,6 +57,9 @@ const styles = StyleSheet.create({
     color: colors.text3,
     letterSpacing: 1.5,
     marginBottom: 10,
+  },
+  scrollArea: {
+    maxHeight: 340,
   },
   pinnedContainer: {
     marginTop: 8,

--- a/components/LeaderboardRow.tsx
+++ b/components/LeaderboardRow.tsx
@@ -1,0 +1,124 @@
+import { View, Text, StyleSheet } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { colors } from "../lib/theme";
+
+interface LeaderboardRowProps {
+  rank: number;
+  username: string;
+  xp: number;
+  tier: string;
+  isCurrentUser: boolean;
+}
+
+export function LeaderboardRow({
+  rank,
+  username,
+  xp,
+  tier,
+  isCurrentUser,
+}: LeaderboardRowProps) {
+  const content = (
+    <>
+      <Text
+        style={[
+          styles.rank,
+          rank === 1 && styles.rankGold,
+          isCurrentUser && styles.rankCurrentUser,
+        ]}
+      >
+        {rank}
+      </Text>
+      <Text
+        style={[
+          styles.username,
+          isCurrentUser && styles.usernameCurrentUser,
+        ]}
+      >
+        {username}
+        {isCurrentUser ? " ⭐" : ""}
+      </Text>
+      <Text
+        style={[
+          styles.tier,
+          isCurrentUser && styles.tierCurrentUser,
+        ]}
+      >
+        {tier}
+      </Text>
+      <Text style={styles.xp}>{xp.toLocaleString()} XP</Text>
+    </>
+  );
+
+  if (isCurrentUser) {
+    return (
+      <LinearGradient
+        colors={[
+          "rgba(245,200,66,0.2)",
+          "rgba(155,109,255,0.25)",
+          "rgba(107,63,212,0.2)",
+        ]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={[styles.row, styles.rowCurrentUser]}
+      >
+        {content}
+      </LinearGradient>
+    );
+  }
+
+  return <View style={[styles.row, styles.rowDefault]}>{content}</View>;
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 12,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    marginBottom: 6,
+  },
+  rowDefault: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  rowCurrentUser: {
+    borderWidth: 1.5,
+    borderColor: colors.primaryLight,
+  },
+  rank: {
+    fontWeight: "800",
+    fontSize: 14,
+    width: 28,
+    color: colors.text2,
+  },
+  rankGold: {
+    color: colors.gold,
+  },
+  rankCurrentUser: {
+    color: colors.gold,
+  },
+  username: {
+    color: colors.text1,
+    fontWeight: "600",
+    fontSize: 14,
+    flex: 1,
+  },
+  usernameCurrentUser: {
+    fontWeight: "700",
+  },
+  tier: {
+    color: colors.text2,
+    fontSize: 12,
+    marginRight: 8,
+  },
+  tierCurrentUser: {
+    color: colors.primaryLight,
+  },
+  xp: {
+    color: colors.gold,
+    fontWeight: "700",
+    fontSize: 13,
+  },
+});

--- a/components/LeaderboardRow.tsx
+++ b/components/LeaderboardRow.tsx
@@ -73,10 +73,10 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     alignItems: "center",
-    padding: 12,
-    paddingHorizontal: 14,
-    borderRadius: 10,
-    marginBottom: 6,
+    padding: 16,
+    paddingHorizontal: 18,
+    borderRadius: 12,
+    marginBottom: 8,
   },
   rowDefault: {
     backgroundColor: colors.surface,

--- a/components/ProfileAvatar.tsx
+++ b/components/ProfileAvatar.tsx
@@ -1,0 +1,44 @@
+import { View, Image, StyleSheet } from "react-native";
+import { colors } from "../lib/theme";
+
+interface ProfileAvatarProps {
+  size?: number;
+}
+
+export function ProfileAvatar({ size = 80 }: ProfileAvatarProps) {
+  const borderRadius = size / 2;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          width: size,
+          height: size,
+          borderRadius,
+        },
+      ]}
+    >
+      <Image
+        source={require("../assets/crack-mascot.png")}
+        style={{
+          width: size - 6,
+          height: size - 6,
+          borderRadius: (size - 6) / 2,
+        }}
+        resizeMode="cover"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 2.5,
+    borderColor: colors.primary,
+    backgroundColor: colors.surface2,
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+  },
+});

--- a/components/StreakCard.tsx
+++ b/components/StreakCard.tsx
@@ -46,8 +46,8 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   flameIcon: {
-    width: 28,
-    height: 28,
+    width: 36,
+    height: 36,
   },
   streakCount: {
     color: colors.gold,

--- a/components/StreakCard.tsx
+++ b/components/StreakCard.tsx
@@ -1,0 +1,75 @@
+import { View, Text, Image, StyleSheet } from "react-native";
+import { colors } from "../lib/theme";
+import { useXpStore } from "../store/useXpStore";
+
+const BEST_STREAK = 12; // Hardcoded for demo — not tracked in store yet
+
+export function StreakCard() {
+  const streakDays = useXpStore((s) => s.streakDays);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.leftSection}>
+        <Image
+          source={require("../assets/streak-flame.png")}
+          style={styles.flameIcon}
+          resizeMode="contain"
+        />
+        <View>
+          <Text style={styles.streakCount}>{streakDays}</Text>
+          <Text style={styles.streakLabel}>day streak</Text>
+        </View>
+      </View>
+      <View style={styles.rightSection}>
+        <Text style={styles.bestLabel}>BEST</Text>
+        <Text style={styles.bestValue}>{BEST_STREAK} days</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 16,
+    paddingHorizontal: 20,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  leftSection: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  flameIcon: {
+    width: 28,
+    height: 28,
+  },
+  streakCount: {
+    color: colors.gold,
+    fontWeight: "900",
+    fontSize: 24,
+  },
+  streakLabel: {
+    color: colors.text2,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  rightSection: {
+    alignItems: "flex-end",
+  },
+  bestLabel: {
+    color: colors.text3,
+    fontSize: 11,
+    fontWeight: "600",
+  },
+  bestValue: {
+    color: colors.text2,
+    fontWeight: "700",
+    fontSize: 16,
+  },
+});

--- a/components/StreakCard.tsx
+++ b/components/StreakCard.tsx
@@ -46,8 +46,8 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   flameIcon: {
-    width: 36,
-    height: 36,
+    width: 48,
+    height: 48,
   },
   streakCount: {
     color: colors.gold,

--- a/components/ZigzagPath.tsx
+++ b/components/ZigzagPath.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, StyleSheet, useWindowDimensions } from "react-native";
 import { colors } from "../lib/theme";
 import type { Topic, Exam } from "../store/useCourseStore";
 
@@ -10,8 +10,7 @@ interface ZigzagPathProps {
 
 const NODE_SIZE = 28;
 const BOSS_NODE_SIZE = 32;
-const CONNECTOR_LENGTH = 24;
-const CONNECTOR_ANGLE = 25;
+const VERTICAL_OFFSET = 18;
 
 function nodeColor(status: Topic["status"]) {
   switch (status) {
@@ -25,103 +24,129 @@ function nodeColor(status: Topic["status"]) {
 }
 
 export default function ZigzagPath({ topics, exams }: ZigzagPathProps) {
+  const { width: screenWidth } = useWindowDimensions();
   const hasUndefeatedExam = exams.some((e) => !e.defeated);
 
-  // Build list of renderable nodes
-  const nodes: Array<
-    | { kind: "topic"; topic: Topic; index: number }
-    | { kind: "boss" }
-  > = topics.map((topic, index) => ({ kind: "topic" as const, topic, index }));
+  const totalNodes = topics.length + (hasUndefeatedExam ? 1 : 0);
+  if (totalNodes === 0) return null;
 
-  if (hasUndefeatedExam) {
-    nodes.push({ kind: "boss" as const });
+  // Calculate horizontal spacing to fit all nodes
+  const availableWidth = screenWidth - 160; // card padding + button area
+  const nodeSpacing = Math.max(NODE_SIZE + 4, availableWidth / totalNodes);
+  const containerHeight = NODE_SIZE + VERTICAL_OFFSET * 2 + 8;
+  const centerY = containerHeight / 2;
+
+  // Build node positions
+  const positions: { x: number; y: number }[] = [];
+  for (let i = 0; i < totalNodes; i++) {
+    const x = i * nodeSpacing + NODE_SIZE / 2;
+    const y = centerY + (i % 2 === 0 ? -VERTICAL_OFFSET : VERTICAL_OFFSET);
+    positions.push({ x, y });
   }
 
   return (
-    <View style={styles.container}>
-      {nodes.map((node, i) => {
-        const isOdd = i % 2 !== 0;
-        const marginTop = isOdd ? -16 : 16;
+    <View style={[styles.container, { height: containerHeight, width: totalNodes * nodeSpacing }]}>
+      {/* Draw connector lines between nodes */}
+      {positions.map((pos, i) => {
+        if (i === 0) return null;
+        const prev = positions[i - 1];
+        const dx = pos.x - prev.x;
+        const dy = pos.y - prev.y;
+        const fullLength = Math.sqrt(dx * dx + dy * dy);
+        const angle = Math.atan2(dy, dx) * (180 / Math.PI);
 
-        // Connector to THIS node (drawn before the node, except for first)
-        let connector: React.ReactNode = null;
-        if (i > 0) {
-          const connectorColor =
-            node.kind === "boss"
-              ? colors.danger
-              : nodeColor(node.topic.status);
+        // Shorten line by the radius of each node so it stops at the circle border
+        const prevRadius = NODE_SIZE / 2;
+        const currRadius = (i < topics.length) ? NODE_SIZE / 2 : BOSS_NODE_SIZE / 2;
+        const shortenTotal = prevRadius + currRadius;
+        const lineLength = Math.max(0, fullLength - shortenTotal);
 
-          const prevIsOdd = (i - 1) % 2 !== 0;
-          // prev odd (up) → current even (down) = angle down (negative)
-          // prev even (down) → current odd (up) = angle up (positive)
-          const rotation = prevIsOdd ? `-${CONNECTOR_ANGLE}deg` : `${CONNECTOR_ANGLE}deg`;
+        // Offset the start point along the direction by prevRadius
+        const unitX = dx / fullLength;
+        const unitY = dy / fullLength;
+        const startX = prev.x + unitX * prevRadius;
+        const startY = prev.y + unitY * prevRadius;
 
-          connector = (
-            <View
-              style={[
-                styles.connector,
-                {
-                  backgroundColor: connectorColor,
-                  transform: [{ rotate: rotation }],
-                },
-              ]}
-            />
-          );
+        // Determine line color from destination node
+        let lineColor: string;
+        if (i < topics.length) {
+          lineColor = nodeColor(topics[i].status);
+        } else {
+          lineColor = colors.danger;
         }
 
-        if (node.kind === "boss") {
-          return (
-            <React.Fragment key="boss">
-              {connector}
-              <View style={[styles.bossNode, { marginTop }]}>
-                <Text style={styles.bossEmoji}>{"\uD83D\uDC79"}</Text>
-              </View>
-            </React.Fragment>
-          );
-        }
+        return (
+          <View
+            key={`line-${i}`}
+            style={{
+              position: "absolute",
+              left: startX,
+              top: startY - 1,
+              width: lineLength,
+              height: 2,
+              backgroundColor: lineColor,
+              transform: [{ rotate: `${angle}deg` }],
+              transformOrigin: "left center",
+            }}
+          />
+        );
+      })}
 
-        const { topic, index } = node;
+      {/* Draw topic nodes */}
+      {topics.map((topic, i) => {
+        const pos = positions[i];
         const isMastered = topic.status === "mastered";
         const isInProgress = topic.status === "in_progress";
         const isLocked = topic.status === "locked";
 
-        const nodeStyles = [
-          styles.node,
-          { marginTop },
-          isMastered && styles.nodeMastered,
-          isInProgress && styles.nodeInProgress,
-          isLocked && styles.nodeLocked,
-        ];
-
         return (
-          <React.Fragment key={topic.id}>
-            {connector}
-            <View style={nodeStyles}>
-              {isMastered ? (
-                <Text style={styles.checkText}>{"\u2713"}</Text>
-              ) : (
-                <Text
-                  style={[
-                    styles.numberText,
-                    isLocked && styles.numberTextLocked,
-                  ]}
-                >
-                  {index + 1}
-                </Text>
-              )}
-            </View>
-          </React.Fragment>
+          <View
+            key={topic.id}
+            style={[
+              styles.node,
+              {
+                position: "absolute",
+                left: pos.x - NODE_SIZE / 2,
+                top: pos.y - NODE_SIZE / 2,
+              },
+              isMastered && styles.nodeMastered,
+              isInProgress && styles.nodeInProgress,
+              isLocked && styles.nodeLocked,
+            ]}
+          >
+            {isMastered ? (
+              <Text style={styles.checkText}>{"\u2713"}</Text>
+            ) : (
+              <Text style={[styles.numberText, isLocked && styles.numberTextLocked]}>
+                {i + 1}
+              </Text>
+            )}
+          </View>
         );
       })}
+
+      {/* Draw boss node */}
+      {hasUndefeatedExam && (
+        <View
+          style={[
+            styles.bossNode,
+            {
+              position: "absolute",
+              left: positions[totalNodes - 1].x - BOSS_NODE_SIZE / 2,
+              top: positions[totalNodes - 1].y - BOSS_NODE_SIZE / 2,
+            },
+          ]}
+        >
+          <Text style={styles.bossEmoji}>{"\uD83D\uDC79"}</Text>
+        </View>
+      )}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    height: 70,
-    flexDirection: "row",
-    alignItems: "center",
+    marginVertical: 8,
   },
   node: {
     width: NODE_SIZE,
@@ -160,10 +185,6 @@ const styles = StyleSheet.create({
   },
   numberTextLocked: {
     color: colors.text3,
-  },
-  connector: {
-    width: CONNECTOR_LENGTH,
-    height: 2,
   },
   bossNode: {
     width: BOSS_NODE_SIZE,

--- a/docs/superpowers/plans/2026-04-03-deep-mode-ui.md
+++ b/docs/superpowers/plans/2026-04-03-deep-mode-ui.md
@@ -1,0 +1,728 @@
+# Deep Mode UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a visually distinct Deep Mode study experience with a transition animation, vignette overlay, pulsing timer, and exit gate (quiz + penalty escape).
+
+**Architecture:** Deep Mode reuses the existing study timer and quiz mechanics but wraps them in new visual components. A transition screen plays first, then the active session shows a vignette overlay. Ending the session shows an exit gate modal instead of immediately ending. The store gets `isOnBreak` and `breakSecondsLeft` state for the break timer.
+
+**Tech Stack:** React Native Animated API, expo-av (Video), existing ChatBubble component, Ionicons, useStudyStore
+
+---
+
+### Task 1: Update useStudyStore with break state
+
+**Files:**
+- Modify: `store/useStudyStore.ts`
+
+- [ ] **Step 1: Add break state and actions to the store**
+
+```tsx
+// store/useStudyStore.ts
+import { create } from "zustand";
+
+interface StudyState {
+  isStudying: boolean;
+  isPaused: boolean;
+  mode: "focus" | "deep" | null;
+  elapsedSeconds: number;
+  currentTopicId: string | null;
+  isOnBreak: boolean;
+  breakSecondsLeft: number;
+  startSession: (mode: "focus" | "deep", topicId: string) => void;
+  pauseSession: () => void;
+  resumeSession: () => void;
+  endSession: () => void;
+  resetSession: () => void;
+  tick: () => void;
+  startBreak: () => void;
+  tickBreak: () => void;
+  endBreak: () => void;
+}
+
+export const useStudyStore = create<StudyState>((set) => ({
+  isStudying: false,
+  isPaused: false,
+  mode: null,
+  elapsedSeconds: 0,
+  currentTopicId: null,
+  isOnBreak: false,
+  breakSecondsLeft: 0,
+  startSession: (mode, topicId) =>
+    set({ isStudying: true, isPaused: false, mode, currentTopicId: topicId, elapsedSeconds: 0, isOnBreak: false, breakSecondsLeft: 0 }),
+  pauseSession: () => set({ isPaused: true }),
+  resumeSession: () => set({ isPaused: false }),
+  endSession: () => set({ isStudying: false, isPaused: false, mode: null, currentTopicId: null }),
+  resetSession: () =>
+    set({ isStudying: false, isPaused: false, mode: null, currentTopicId: null, elapsedSeconds: 0, isOnBreak: false, breakSecondsLeft: 0 }),
+  tick: () => set((s) => ({ elapsedSeconds: s.elapsedSeconds + 1 })),
+  startBreak: () => set({ isOnBreak: true, isPaused: true, breakSecondsLeft: 300 }),
+  tickBreak: () =>
+    set((s) => {
+      if (s.breakSecondsLeft <= 1) {
+        return { isOnBreak: false, breakSecondsLeft: 0 };
+      }
+      return { breakSecondsLeft: s.breakSecondsLeft - 1 };
+    }),
+  endBreak: () => set({ isOnBreak: false, breakSecondsLeft: 0, isPaused: false }),
+}));
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add store/useStudyStore.ts
+git commit -m "feat: add break timer state to useStudyStore for Deep Mode"
+```
+
+---
+
+### Task 2: Deep Mode Transition Screen
+
+**Files:**
+- Create: `components/DeepModeTransition.tsx`
+
+- [ ] **Step 1: Create transition component**
+
+This component shows for ~3 seconds when Deep Mode starts: black background, Crack video playing, "Lock in" ChatBubble on top.
+
+```tsx
+// components/DeepModeTransition.tsx
+import { useEffect, useState } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { Video, ResizeMode } from "expo-av";
+import { colors } from "../lib/theme";
+
+interface Props {
+  onComplete: () => void;
+}
+
+export default function DeepModeTransition({ onComplete }: Props) {
+  const [showBubble, setShowBubble] = useState(false);
+
+  useEffect(() => {
+    // Show bubble after a short delay
+    const bubbleTimer = setTimeout(() => setShowBubble(true), 400);
+    // Auto-advance after 3 seconds
+    const advanceTimer = setTimeout(() => onComplete(), 3000);
+    return () => {
+      clearTimeout(bubbleTimer);
+      clearTimeout(advanceTimer);
+    };
+  }, [onComplete]);
+
+  return (
+    <View style={styles.container}>
+      {/* Speech bubble */}
+      {showBubble && (
+        <View style={styles.bubbleWrap}>
+          <View style={styles.bubble}>
+            <Text style={styles.bubbleText}>Lock in</Text>
+          </View>
+          <View style={styles.spikeWrap}>
+            <View style={styles.spikeOuter} />
+            <View style={styles.spikeInner} />
+          </View>
+        </View>
+      )}
+
+      {/* Video */}
+      <Video
+        source={require("../assets/crack-deep-mode.mp4")}
+        style={styles.video}
+        resizeMode={ResizeMode.CONTAIN}
+        shouldPlay
+        isLooping={false}
+        isMuted
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#000000",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  bubbleWrap: {
+    alignItems: "center",
+    marginBottom: -8,
+    zIndex: 10,
+  },
+  bubble: {
+    backgroundColor: colors.surface2,
+    borderRadius: 16,
+    borderWidth: 1.5,
+    borderColor: colors.primary,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+  },
+  bubbleText: {
+    color: colors.text1,
+    fontSize: 20,
+    fontWeight: "800",
+    letterSpacing: 0.5,
+    textAlign: "center",
+  },
+  spikeWrap: {
+    alignSelf: "center",
+    position: "relative",
+  },
+  spikeOuter: {
+    width: 0,
+    height: 0,
+    borderLeftWidth: 10,
+    borderRightWidth: 10,
+    borderTopWidth: 14,
+    borderLeftColor: "transparent",
+    borderRightColor: "transparent",
+    borderTopColor: colors.primary,
+  },
+  spikeInner: {
+    position: "absolute",
+    top: -1.5,
+    left: 1.5,
+    width: 0,
+    height: 0,
+    borderLeftWidth: 8.5,
+    borderRightWidth: 8.5,
+    borderTopWidth: 12.5,
+    borderLeftColor: "transparent",
+    borderRightColor: "transparent",
+    borderTopColor: colors.surface2,
+  },
+  video: {
+    width: 280,
+    height: 280,
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/DeepModeTransition.tsx
+git commit -m "feat: add Deep Mode transition screen with video and Lock in bubble"
+```
+
+---
+
+### Task 3: Deep Mode Overlay (Vignette + Pulsing Timer)
+
+**Files:**
+- Create: `components/DeepModeOverlay.tsx`
+
+- [ ] **Step 1: Create overlay component**
+
+This wraps the active timer view when in Deep Mode. It adds a vignette border, lock icon header, and pulsing glow on the timer.
+
+```tsx
+// components/DeepModeOverlay.tsx
+import { useEffect, useRef } from "react";
+import { View, Text, Animated, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { colors } from "../lib/theme";
+
+interface Props {
+  elapsedSeconds: number;
+  isOnBreak: boolean;
+  breakSecondsLeft: number;
+}
+
+function formatTime(totalSeconds: number): string {
+  const mm = Math.floor(totalSeconds / 60).toString().padStart(2, "0");
+  const ss = (totalSeconds % 60).toString().padStart(2, "0");
+  return `${mm}:${ss}`;
+}
+
+export default function DeepModeOverlay({ elapsedSeconds, isOnBreak, breakSecondsLeft }: Props) {
+  const glowAnim = useRef(new Animated.Value(8)).current;
+
+  useEffect(() => {
+    const pulse = Animated.loop(
+      Animated.sequence([
+        Animated.timing(glowAnim, { toValue: 20, duration: 1000, useNativeDriver: false }),
+        Animated.timing(glowAnim, { toValue: 8, duration: 1000, useNativeDriver: false }),
+      ])
+    );
+    pulse.start();
+    return () => pulse.stop();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      {/* Vignette edges */}
+      <View style={styles.vignetteTop} />
+      <View style={styles.vignetteBottom} />
+      <View style={styles.vignetteLeft} />
+      <View style={styles.vignetteRight} />
+
+      {/* Header */}
+      <View style={styles.header}>
+        <Ionicons name="lock-closed" size={16} color={colors.primaryLight} />
+        <Text style={styles.headerText}>DEEP MODE</Text>
+      </View>
+
+      {/* Timer with pulsing glow */}
+      <View style={styles.timerWrap}>
+        <Animated.Text
+          style={[
+            styles.timer,
+            {
+              textShadowColor: colors.primary,
+              textShadowRadius: glowAnim,
+            },
+          ]}
+        >
+          {formatTime(elapsedSeconds)}
+        </Animated.Text>
+      </View>
+
+      {/* Break timer */}
+      {isOnBreak && (
+        <View style={styles.breakWrap}>
+          <Text style={styles.breakLabel}>BREAK</Text>
+          <Text style={styles.breakTimer}>{formatTime(breakSecondsLeft)}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  vignetteTop: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 120,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  vignetteBottom: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 120,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  vignetteLeft: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: 40,
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  vignetteRight: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    right: 0,
+    width: 40,
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  header: {
+    position: "absolute",
+    top: 60,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  headerText: {
+    color: colors.primaryLight,
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 1.5,
+  },
+  timerWrap: {
+    alignItems: "center",
+  },
+  timer: {
+    fontSize: 72,
+    fontWeight: "800",
+    color: colors.text1,
+    letterSpacing: -2,
+    textShadowOffset: { width: 0, height: 0 },
+  },
+  breakWrap: {
+    marginTop: 20,
+    alignItems: "center",
+  },
+  breakLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: colors.gold,
+    letterSpacing: 1.5,
+  },
+  breakTimer: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: colors.gold,
+    marginTop: 4,
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/DeepModeOverlay.tsx
+git commit -m "feat: add DeepModeOverlay with vignette, lock header, pulsing timer"
+```
+
+---
+
+### Task 4: Exit Gate Modal
+
+**Files:**
+- Create: `components/ExitGateModal.tsx`
+
+- [ ] **Step 1: Create exit gate modal**
+
+Shows two paths: quiz gate (answer to earn break) or penalty escape (-20 XP).
+
+```tsx
+// components/ExitGateModal.tsx
+import { useState } from "react";
+import { View, Text, TouchableOpacity, Modal, StyleSheet } from "react-native";
+import { colors, radii } from "../lib/theme";
+import { QUESTION_BANK, QuizQuestion } from "../lib/questionBank";
+
+interface Props {
+  visible: boolean;
+  topicId: string;
+  daysUntilExam: number | null;
+  onStay: () => void;
+  onQuizCorrect: () => void;
+  onPenaltyExit: () => void;
+}
+
+export default function ExitGateModal({
+  visible,
+  topicId,
+  daysUntilExam,
+  onStay,
+  onQuizCorrect,
+  onPenaltyExit,
+}: Props) {
+  const [phase, setPhase] = useState<"choose" | "quiz" | "wrong">("choose");
+  const [question, setQuestion] = useState<QuizQuestion | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  const loadQuestion = () => {
+    const pool = QUESTION_BANK.filter((q) => q.topicId === topicId);
+    if (pool.length === 0) return;
+    setQuestion(pool[Math.floor(Math.random() * pool.length)]);
+    setSelectedIndex(null);
+    setPhase("quiz");
+  };
+
+  const handleAnswer = (index: number) => {
+    if (selectedIndex !== null || !question) return;
+    setSelectedIndex(index);
+    setTimeout(() => {
+      if (index === question.correctIndex) {
+        setPhase("choose");
+        setQuestion(null);
+        setSelectedIndex(null);
+        onQuizCorrect();
+      } else {
+        setPhase("wrong");
+      }
+    }, 800);
+  };
+
+  const handleClose = () => {
+    setPhase("choose");
+    setQuestion(null);
+    setSelectedIndex(null);
+    onStay();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={handleClose}>
+      <View style={styles.overlay}>
+        <View style={styles.card}>
+          {/* Choose phase */}
+          {phase === "choose" && (
+            <>
+              <Text style={styles.title}>End Deep Mode?</Text>
+              <Text style={styles.body}>
+                -20 XP penalty.{daysUntilExam ? ` Your midterm is in ${daysUntilExam} ${daysUntilExam === 1 ? "day" : "days"}.` : ""}
+              </Text>
+
+              <TouchableOpacity style={styles.quizButton} onPress={loadQuestion}>
+                <Text style={styles.quizButtonText}>ANSWER A QUESTION INSTEAD</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity style={styles.stayButton} onPress={handleClose}>
+                <Text style={styles.stayButtonText}>STAY</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity style={styles.leaveButton} onPress={onPenaltyExit}>
+                <Text style={styles.leaveButtonText}>LEAVE (-20 XP)</Text>
+              </TouchableOpacity>
+            </>
+          )}
+
+          {/* Quiz phase */}
+          {phase === "quiz" && question && (
+            <>
+              <Text style={styles.quizLabel}>Answer correctly for a 5-min break</Text>
+              <Text style={styles.questionText}>{question.question}</Text>
+              {question.options.map((opt, i) => {
+                const isSelected = selectedIndex === i;
+                const isCorrect = i === question.correctIndex;
+                const showResult = selectedIndex !== null;
+                return (
+                  <TouchableOpacity
+                    key={i}
+                    style={[
+                      styles.optionButton,
+                      showResult && isSelected && isCorrect && styles.optionCorrect,
+                      showResult && isSelected && !isCorrect && styles.optionWrong,
+                    ]}
+                    onPress={() => handleAnswer(i)}
+                    disabled={selectedIndex !== null}
+                  >
+                    <Text style={[
+                      styles.optionText,
+                      showResult && isSelected && isCorrect && { color: colors.success },
+                      showResult && isSelected && !isCorrect && { color: colors.danger },
+                    ]}>
+                      {opt}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </>
+          )}
+
+          {/* Wrong answer phase */}
+          {phase === "wrong" && (
+            <>
+              <Text style={styles.title}>Not quite!</Text>
+              <Text style={styles.body}>
+                Keep going — you've got this.{daysUntilExam ? ` Midterm in ${daysUntilExam} ${daysUntilExam === 1 ? "day" : "days"}.` : ""}
+              </Text>
+
+              <TouchableOpacity style={styles.quizButton} onPress={loadQuestion}>
+                <Text style={styles.quizButtonText}>TRY ANOTHER QUESTION</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity style={styles.stayButton} onPress={handleClose}>
+                <Text style={styles.stayButtonText}>BACK TO STUDYING</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity style={styles.leaveButton} onPress={onPenaltyExit}>
+                <Text style={styles.leaveButtonText}>LEAVE (-20 XP)</Text>
+              </TouchableOpacity>
+            </>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.8)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: radii.lg,
+    padding: 24,
+    width: "100%",
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "800",
+    color: colors.text1,
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 14,
+    color: colors.text2,
+    textAlign: "center",
+    marginBottom: 24,
+    lineHeight: 20,
+  },
+  quizButton: {
+    backgroundColor: colors.primary,
+    borderRadius: radii.pill,
+    paddingVertical: 16,
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  quizButtonText: {
+    color: "#FFF",
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 0.8,
+  },
+  stayButton: {
+    backgroundColor: colors.surface3,
+    borderRadius: radii.pill,
+    paddingVertical: 14,
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  stayButtonText: {
+    color: colors.text1,
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 0.8,
+  },
+  leaveButton: {
+    borderWidth: 1.5,
+    borderColor: colors.danger,
+    borderRadius: radii.pill,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  leaveButtonText: {
+    color: colors.danger,
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 0.8,
+  },
+  quizLabel: {
+    fontSize: 11,
+    color: colors.text3,
+    fontWeight: "600",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  questionText: {
+    fontSize: 16,
+    color: colors.text1,
+    fontWeight: "600",
+    lineHeight: 24,
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  optionButton: {
+    backgroundColor: colors.surface3,
+    borderRadius: radii.md,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  optionCorrect: {
+    borderColor: colors.success,
+    backgroundColor: "rgba(78,255,180,0.1)",
+  },
+  optionWrong: {
+    borderColor: colors.danger,
+    backgroundColor: "rgba(255,87,87,0.1)",
+  },
+  optionText: {
+    fontSize: 14,
+    color: colors.text1,
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/ExitGateModal.tsx
+git commit -m "feat: add ExitGateModal with quiz gate and penalty escape"
+```
+
+---
+
+### Task 5: Integrate Deep Mode into Study Screen
+
+**Files:**
+- Modify: `app/(tabs)/study.tsx`
+
+- [ ] **Step 1: Add Deep Mode integration to the study screen**
+
+This is the integration task. The study screen needs:
+1. A `deepPhase` state: `null | "transition" | "active"` — controls whether to show the transition or the active overlay
+2. When `selectedMode === "deep"` and user starts: set `deepPhase = "transition"` instead of going straight to active timer
+3. When transition completes (3s): set `deepPhase = "active"`, start the timer
+4. When Deep Mode active: render `DeepModeOverlay` on top of the timer view
+5. When "End Session" tapped in Deep Mode: show `ExitGateModal` instead of ending
+6. Handle quiz correct (start break), penalty exit (deduct 20 XP, end session), stay (dismiss modal)
+7. Break timer: tick down from 300s, show "Break over" when done
+
+The study screen is large (~400+ lines). The subagent should read the current `app/(tabs)/study.tsx` file first to understand the existing structure, then:
+
+- Add imports: `DeepModeTransition`, `DeepModeOverlay`, `ExitGateModal`
+- Add state: `deepPhase`, `exitGateVisible`
+- Modify `handleStartSession`: if deep mode, set `deepPhase = "transition"` instead of going to active view immediately
+- Add `handleTransitionComplete`: set `deepPhase = "active"`, call `startSession`
+- Modify `handleEndSession`: if deep mode, show exit gate instead of ending
+- Add `handleQuizCorrect`: call `startBreak()` from store, dismiss exit gate, show toast "5 min break earned!"
+- Add `handlePenaltyExit`: deduct 20 XP (`addXp(-20)`), end session, go to summary
+- Add break timer `useEffect`: when `isOnBreak`, tick break every 1s
+- Render `DeepModeTransition` when `deepPhase === "transition"`
+- Render `DeepModeOverlay` when `deepPhase === "active"` and mode is deep
+- Render `ExitGateModal` controlled by `exitGateVisible`
+- Calculate `daysUntilExam` from the current topic's course for the exit gate
+
+Focus Mode should remain completely unchanged.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Test in Expo Go**
+
+- Select Deep Mode → Start → transition video plays with "Lock in" bubble → after 3s timer appears with vignette + pulsing glow + lock icon
+- Tap End Session → exit gate modal (not direct end)
+- Tap "Answer a question" → quiz appears → correct → "5 min break earned!" + break timer
+- Wrong answer → encouragement + try again / leave options
+- Tap "Leave (-20 XP)" → session ends, -20 XP
+- Tap "Stay" → modal dismisses, session continues
+- Select Focus Mode → everything works as before (no vignette, no exit gate)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/\(tabs\)/study.tsx
+git commit -m "feat: integrate Deep Mode transition, overlay, and exit gate into study screen"
+```

--- a/docs/superpowers/plans/2026-04-03-profile-leaderboard.md
+++ b/docs/superpowers/plans/2026-04-03-profile-leaderboard.md
@@ -1,0 +1,624 @@
+# Profile & Leaderboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the Profile tab with an avatar, streak card, and global leaderboard with highlighted current user.
+
+**Architecture:** Four new components (`ProfileAvatar`, `StreakCard`, `LeaderboardRow`, `LeaderboardList`) composed into the existing profile screen below the XP section from issue #4. Current user's leaderboard row uses a gold-to-purple gradient via `expo-linear-gradient`.
+
+**Tech Stack:** React Native, Expo, expo-linear-gradient, Zustand, TypeScript, StyleSheet.create()
+
+**Spec:** `docs/superpowers/specs/2026-04-03-profile-leaderboard-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `components/ProfileAvatar.tsx` | Create | Crack mascot in circular container |
+| `components/StreakCard.tsx` | Create | Flame icon, current streak, best streak |
+| `components/LeaderboardRow.tsx` | Create | Single leaderboard row with gradient for current user |
+| `components/LeaderboardList.tsx` | Create | Section header, ranked rows, pinned user row |
+| `app/(tabs)/profile.tsx` | Modify | Add avatar, streak card, leaderboard below existing XP section |
+
+---
+
+### Task 1: Install expo-linear-gradient
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install the package**
+
+```bash
+cd /Users/bird/cracked-quest && npx expo install expo-linear-gradient
+```
+
+- [ ] **Step 2: Verify it installed**
+
+```bash
+grep "expo-linear-gradient" package.json
+```
+
+Expected: A line showing `"expo-linear-gradient"` in dependencies.
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd /Users/bird/cracked-quest && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "deps: add expo-linear-gradient for leaderboard user highlight"
+```
+
+---
+
+### Task 2: Create `components/ProfileAvatar.tsx`
+
+**Files:**
+- Create: `components/ProfileAvatar.tsx`
+
+- [ ] **Step 1: Create the avatar component**
+
+```typescript
+// components/ProfileAvatar.tsx
+
+import { View, Image, StyleSheet } from "react-native";
+import { colors } from "../lib/theme";
+
+interface ProfileAvatarProps {
+  size?: number;
+}
+
+export function ProfileAvatar({ size = 80 }: ProfileAvatarProps) {
+  const borderRadius = size / 2;
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          width: size,
+          height: size,
+          borderRadius,
+        },
+      ]}
+    >
+      <Image
+        source={require("../assets/crack-mascot.png")}
+        style={{
+          width: size - 6,
+          height: size - 6,
+          borderRadius: (size - 6) / 2,
+        }}
+        resizeMode="cover"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 2.5,
+    borderColor: colors.primary,
+    backgroundColor: colors.surface2,
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/bird/cracked-quest && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/ProfileAvatar.tsx
+git commit -m "feat(profile): add ProfileAvatar component with Crack mascot"
+```
+
+---
+
+### Task 3: Create `components/StreakCard.tsx`
+
+**Files:**
+- Create: `components/StreakCard.tsx`
+
+- [ ] **Step 1: Create the streak card component**
+
+```typescript
+// components/StreakCard.tsx
+
+import { View, Text, Image, StyleSheet } from "react-native";
+import { colors } from "../lib/theme";
+import { useXpStore } from "../store/useXpStore";
+
+const BEST_STREAK = 12; // Hardcoded for demo — not tracked in store yet
+
+export function StreakCard() {
+  const streakDays = useXpStore((s) => s.streakDays);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.leftSection}>
+        <Image
+          source={require("../assets/streak-flame.png")}
+          style={styles.flameIcon}
+          resizeMode="contain"
+        />
+        <View>
+          <Text style={styles.streakCount}>{streakDays}</Text>
+          <Text style={styles.streakLabel}>day streak</Text>
+        </View>
+      </View>
+      <View style={styles.rightSection}>
+        <Text style={styles.bestLabel}>BEST</Text>
+        <Text style={styles.bestValue}>{BEST_STREAK} days</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 16,
+    paddingHorizontal: 20,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  leftSection: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  flameIcon: {
+    width: 28,
+    height: 28,
+  },
+  streakCount: {
+    color: colors.gold,
+    fontWeight: "900",
+    fontSize: 24,
+  },
+  streakLabel: {
+    color: colors.text2,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  rightSection: {
+    alignItems: "flex-end",
+  },
+  bestLabel: {
+    color: colors.text3,
+    fontSize: 11,
+    fontWeight: "600",
+  },
+  bestValue: {
+    color: colors.text2,
+    fontWeight: "700",
+    fontSize: 16,
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/bird/cracked-quest && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/StreakCard.tsx
+git commit -m "feat(profile): add StreakCard component with custom flame icon"
+```
+
+---
+
+### Task 4: Create `components/LeaderboardRow.tsx`
+
+**Files:**
+- Create: `components/LeaderboardRow.tsx`
+
+- [ ] **Step 1: Create the leaderboard row component**
+
+```typescript
+// components/LeaderboardRow.tsx
+
+import { View, Text, StyleSheet } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { colors } from "../lib/theme";
+
+interface LeaderboardRowProps {
+  rank: number;
+  username: string;
+  xp: number;
+  tier: string;
+  isCurrentUser: boolean;
+}
+
+export function LeaderboardRow({
+  rank,
+  username,
+  xp,
+  tier,
+  isCurrentUser,
+}: LeaderboardRowProps) {
+  const content = (
+    <>
+      <Text
+        style={[
+          styles.rank,
+          rank === 1 && styles.rankGold,
+          isCurrentUser && styles.rankCurrentUser,
+        ]}
+      >
+        {rank}
+      </Text>
+      <Text
+        style={[
+          styles.username,
+          isCurrentUser && styles.usernameCurrentUser,
+        ]}
+      >
+        {username}
+        {isCurrentUser ? " ⭐" : ""}
+      </Text>
+      <Text
+        style={[
+          styles.tier,
+          isCurrentUser && styles.tierCurrentUser,
+        ]}
+      >
+        {tier}
+      </Text>
+      <Text style={styles.xp}>{xp.toLocaleString()} XP</Text>
+    </>
+  );
+
+  if (isCurrentUser) {
+    return (
+      <LinearGradient
+        colors={[
+          "rgba(245,200,66,0.2)",
+          "rgba(155,109,255,0.25)",
+          "rgba(107,63,212,0.2)",
+        ]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={[styles.row, styles.rowCurrentUser]}
+      >
+        {content}
+      </LinearGradient>
+    );
+  }
+
+  return <View style={[styles.row, styles.rowDefault]}>{content}</View>;
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 12,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    marginBottom: 6,
+  },
+  rowDefault: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  rowCurrentUser: {
+    borderWidth: 1.5,
+    borderColor: colors.primaryLight,
+  },
+  rank: {
+    fontWeight: "800",
+    fontSize: 14,
+    width: 28,
+    color: colors.text2,
+  },
+  rankGold: {
+    color: colors.gold,
+  },
+  rankCurrentUser: {
+    color: colors.gold,
+  },
+  username: {
+    color: colors.text1,
+    fontWeight: "600",
+    fontSize: 14,
+    flex: 1,
+  },
+  usernameCurrentUser: {
+    fontWeight: "700",
+  },
+  tier: {
+    color: colors.text2,
+    fontSize: 12,
+    marginRight: 8,
+  },
+  tierCurrentUser: {
+    color: colors.primaryLight,
+  },
+  xp: {
+    color: colors.gold,
+    fontWeight: "700",
+    fontSize: 13,
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/bird/cracked-quest && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/LeaderboardRow.tsx
+git commit -m "feat(profile): add LeaderboardRow with gold-to-purple gradient for current user"
+```
+
+---
+
+### Task 5: Create `components/LeaderboardList.tsx`
+
+**Files:**
+- Create: `components/LeaderboardList.tsx`
+
+- [ ] **Step 1: Create the leaderboard list component**
+
+```typescript
+// components/LeaderboardList.tsx
+
+import { View, Text, StyleSheet } from "react-native";
+import { colors } from "../lib/theme";
+import { DEMO_LEADERBOARD } from "../lib/mockData";
+import { LeaderboardRow } from "./LeaderboardRow";
+
+interface LeaderboardListProps {
+  currentUsername: string;
+}
+
+export function LeaderboardList({ currentUsername }: LeaderboardListProps) {
+  const sorted = [...DEMO_LEADERBOARD].sort((a, b) => b.xp - a.xp);
+
+  const currentUserEntry = sorted.find(
+    (entry) => entry.username === currentUsername
+  );
+  const currentUserRank = currentUserEntry
+    ? sorted.indexOf(currentUserEntry) + 1
+    : null;
+
+  return (
+    <View>
+      <Text style={styles.sectionLabel}>LEADERBOARD</Text>
+
+      {sorted.map((entry, index) => (
+        <LeaderboardRow
+          key={entry.username}
+          rank={index + 1}
+          username={entry.username}
+          xp={entry.xp}
+          tier={entry.tier}
+          isCurrentUser={entry.username === currentUsername}
+        />
+      ))}
+
+      {currentUserEntry && currentUserRank && (
+        <View style={styles.pinnedContainer}>
+          <LeaderboardRow
+            rank={currentUserRank}
+            username={currentUserEntry.username}
+            xp={currentUserEntry.xp}
+            tier={currentUserEntry.tier}
+            isCurrentUser={true}
+          />
+          <Text style={styles.pinnedLabel}>Your position</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: colors.text3,
+    letterSpacing: 1.5,
+    marginBottom: 10,
+  },
+  pinnedContainer: {
+    marginTop: 8,
+  },
+  pinnedLabel: {
+    fontSize: 10,
+    color: colors.text3,
+    textAlign: "center",
+    marginTop: -2,
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/bird/cracked-quest && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/LeaderboardList.tsx
+git commit -m "feat(profile): add LeaderboardList with ranked rows and pinned user position"
+```
+
+---
+
+### Task 6: Integrate into Profile tab (`app/(tabs)/profile.tsx`)
+
+**Files:**
+- Modify: `app/(tabs)/profile.tsx`
+
+- [ ] **Step 1: Update profile.tsx with avatar, streak card, and leaderboard**
+
+Replace the entire contents of `app/(tabs)/profile.tsx` with:
+
+```typescript
+import { View, Text, StyleSheet, ScrollView } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { colors } from "../../lib/theme";
+import { getCurrentTier } from "../../lib/xpUtils";
+import { useAuthStore } from "../../store/useAuthStore";
+import { useXpStore } from "../../store/useXpStore";
+import { useXpAnimation } from "../../hooks/useXpAnimation";
+import { XpProgressBar } from "../../components/XpProgressBar";
+import { XpAnimatedCounter } from "../../components/XpAnimatedCounter";
+import { RankBadge } from "../../components/RankBadge";
+import { ProfileAvatar } from "../../components/ProfileAvatar";
+import { StreakCard } from "../../components/StreakCard";
+import { LeaderboardList } from "../../components/LeaderboardList";
+
+export default function ProfileScreen() {
+  const user = useAuthStore((s) => s.user);
+  const xpTotal = useXpStore((s) => s.xpTotal);
+  const tier = getCurrentTier(xpTotal);
+  const { animatedXp, displayXp } = useXpAnimation();
+
+  const username = user?.username ?? "DemoStudent";
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        {/* Avatar */}
+        <View style={styles.avatarContainer}>
+          <ProfileAvatar size={80} />
+        </View>
+
+        {/* Username */}
+        <Text style={styles.username}>{username}</Text>
+        <Text style={styles.university}>McGill University</Text>
+
+        {/* Shield badge */}
+        <View style={styles.badgeContainer}>
+          <RankBadge tier={tier} variant="shield" />
+        </View>
+
+        {/* XP counter */}
+        <View style={styles.counterContainer}>
+          <XpAnimatedCounter displayXp={displayXp} size="full" />
+        </View>
+
+        {/* XP progress bar */}
+        <View style={styles.barContainer}>
+          <XpProgressBar animatedXp={animatedXp} size="full" />
+        </View>
+
+        {/* Divider */}
+        <View style={styles.divider} />
+
+        {/* Streak Card */}
+        <View style={styles.streakContainer}>
+          <StreakCard />
+        </View>
+
+        {/* Leaderboard */}
+        <View style={styles.leaderboardContainer}>
+          <LeaderboardList currentUsername={username} />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bg,
+  },
+  content: {
+    paddingBottom: 48,
+  },
+  avatarContainer: {
+    alignItems: "center",
+    marginTop: 24,
+  },
+  username: {
+    color: colors.text1,
+    fontWeight: "800",
+    fontSize: 22,
+    textAlign: "center",
+    marginTop: 10,
+    marginBottom: 4,
+  },
+  university: {
+    color: colors.text3,
+    fontSize: 12,
+    textAlign: "center",
+  },
+  badgeContainer: {
+    alignItems: "center",
+    marginTop: 16,
+  },
+  counterContainer: {
+    marginTop: 24,
+  },
+  barContainer: {
+    marginTop: 12,
+    paddingHorizontal: 32,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginHorizontal: 20,
+    marginTop: 16,
+  },
+  streakContainer: {
+    marginTop: 16,
+    marginHorizontal: 20,
+  },
+  leaderboardContainer: {
+    marginTop: 16,
+    paddingHorizontal: 20,
+  },
+});
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/bird/cracked-quest && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Run the app and visually verify**
+
+Run: `cd /Users/bird/cracked-quest && npx expo start`
+
+Check:
+- Profile tab shows: Crack mascot avatar at top, username, shield badge, XP counter + bar
+- Below divider: streak card with custom flame icon, streak count
+- Leaderboard with 5 rows, DemoStudent at #3 with gold-to-purple gradient
+- Pinned "Your position" row at the bottom
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/\(tabs\)/profile.tsx
+git commit -m "feat(profile): integrate avatar, streak card, and leaderboard into Profile tab"
+```

--- a/docs/superpowers/specs/2026-04-03-deep-mode-ui-design.md
+++ b/docs/superpowers/specs/2026-04-03-deep-mode-ui-design.md
@@ -7,8 +7,8 @@ The study screen already supports Focus and Deep mode selection, a timer, and qu
 ## Entry Flow
 
 1. User selects "Deep" mode on study setup screen and taps Start Session
-2. Crack serious mode animation plays (video asset — placeholder static image until asset is provided)
-3. Screen transitions to Deep Mode UI
+2. **Transition screen:** Full-screen black background, Crack serious mode video plays (`assets/crack-deep-mode.mp4`), "Lock in" speech bubble appears on top of mascot (same ChatBubble component from onboarding with purple border and spike pointing down). Video loops once, transition auto-advances after ~3 seconds.
+3. Screen transitions to Deep Mode active session UI
 
 ## Deep Mode Active Session
 

--- a/docs/superpowers/specs/2026-04-03-deep-mode-ui-design.md
+++ b/docs/superpowers/specs/2026-04-03-deep-mode-ui-design.md
@@ -1,0 +1,78 @@
+# Issue #10: Deep Mode UI — Design Spec
+
+## Context
+
+The study screen already supports Focus and Deep mode selection, a timer, and quiz checkpoints. Deep Mode needs a distinct visual identity — it should feel like entering a boss arena, not just a different timer. For the demo, no real OS-level blocking — just visual and UX changes.
+
+## Entry Flow
+
+1. User selects "Deep" mode on study setup screen and taps Start Session
+2. Crack serious mode animation plays (video asset — placeholder static image until asset is provided)
+3. Screen transitions to Deep Mode UI
+
+## Deep Mode Active Session
+
+**Visual changes from Focus Mode:**
+- Background: deeper dark with vignette overlay (radial gradient from transparent center to black edges)
+- Lock icon in header next to mode label ("DEEP MODE 🔒")
+- Timer: larger, more dramatic — pulsing purple glow shadow animation on the timer text
+- Overall feel: boss arena — darker, more intense, minimal distractions
+
+**Functional — same as Focus Mode:**
+- Timer counting up (tick logic from useStudyStore)
+- Pause/resume available
+- Quiz checkpoint button available
+- XP awarded on session end via award_xp Edge Function
+
+## Exit Flow
+
+When user taps "End Session" during Deep Mode, show an exit gate instead of immediately ending:
+
+### Exit Gate Modal
+
+Two paths presented side by side or stacked:
+
+**Path 1 — Quiz Gate (no penalty):**
+- "Answer a question to earn a break"
+- Shows a quiz question from the current topic
+- Correct answer → session pauses, 5-minute break timer starts, toast "5 min break earned!"
+- Wrong answer → modal stays, shows encouragement + exam countdown, user can try another question or choose penalty exit
+- After break timer ends → soft notification "Break over. Back to it?"
+
+**Path 2 — Penalty Escape:**
+- Straightforward modal, no mascot
+- Title: "End Deep Mode?"
+- Body: "-20 XP penalty. Your midterm is in 8 days."
+- Days calculated from nearest future undefeated exam for the current topic's course
+- Two buttons:
+  - "Stay" (primary purple pill) — dismisses modal, resumes session
+  - "Leave (-20 XP)" (outline/danger style) — ends session, deducts 20 XP, goes to summary
+
+## Files to Create/Modify
+
+- **Modify:** `app/(tabs)/study.tsx` — add Deep Mode visual state, exit gate logic, break timer
+- **Create:** `components/DeepModeOverlay.tsx` — vignette overlay, pulsing glow, lock icon header
+- **Create:** `components/ExitGateModal.tsx` — quiz gate + penalty escape modal
+- **Modify:** `store/useStudyStore.ts` — add `isOnBreak` state and break timer logic
+
+## Design Tokens
+
+| Element | Value |
+|---------|-------|
+| Vignette | Radial gradient, rgba(0,0,0,0.8) edges to transparent center |
+| Timer glow | shadowColor #9B6DFF, animated shadowRadius 8→20→8, 2s loop |
+| Lock icon | Ionicons `lock-closed` 16px, #B99BFF, next to mode label |
+| Penalty modal bg | colors.surface (#141418) |
+| "Stay" button | Primary purple pill |
+| "Leave" button | Outline, borderColor colors.danger, text colors.danger |
+| Break timer | Smaller text below main timer, gold color (#F5C842) |
+
+## Verification
+
+1. `npx tsc --noEmit` — clean compile
+2. Select Deep Mode on setup → start → see vignette + pulsing timer + lock icon
+3. Tap End Session → exit gate modal appears (not immediate end)
+4. Quiz gate: correct answer → break timer starts, wrong → encouragement shown
+5. Penalty escape: confirm → -20 XP deducted, session ends
+6. "Stay" → modal dismisses, session continues
+7. Focus Mode unchanged — no vignette, no exit gate, direct end

--- a/docs/superpowers/specs/2026-04-03-profile-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-04-03-profile-leaderboard-design.md
@@ -46,7 +46,7 @@ Props: `size?: number` (default 80)
 No props — reads `streakDays` from `useXpStore`.
 
 - Card: `colors.surface` background, `colors.border` border, `borderRadius: 14`
-- Left side: 🔥 emoji (28px) + streak count (24px bold gold) + "day streak" label
+- Left side: custom flame image (`assets/streak-flame.png`, 28x28) + streak count (24px bold gold) + "day streak" label
 - Right side: "BEST" label + hardcoded best streak value (e.g. 12 days)
 - Best streak is hardcoded for demo — `useXpStore` doesn't track it yet
 

--- a/docs/superpowers/specs/2026-04-03-profile-leaderboard-design.md
+++ b/docs/superpowers/specs/2026-04-03-profile-leaderboard-design.md
@@ -1,0 +1,113 @@
+# Profile & Leaderboard Screen — Design Spec
+
+**Issue:** #5 — P0: Profile & Leaderboard Screen
+**Date:** 2026-04-03
+**Depends on:** #4 (XP & Rank Display — complete)
+
+## Overview
+
+Expand the Profile tab with an avatar, streak card, and leaderboard. The existing XP section (shield badge, counter, progress bar from issue #4) stays untouched. New content goes below the divider.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Avatar | Crack mascot in purple circle (swappable later) | Simple default, custom avatars are a future feature |
+| Streak display | Dedicated card with current + best streak | Prominent game feel, not just inline text |
+| Leaderboard scope | Global (all students) | Simplest for demo, per-course filtering is future work |
+| User highlight | Gold-to-purple gradient background | Pimping, valorizes user rank, eye-catching |
+| Pinned row | Always show user position at bottom | User always sees their rank even in longer lists |
+| Layout | Keep existing XP section, add below divider | Minimal changes to working code |
+| Architecture | Composed small components | Focused files, reusable, matches issue #4 pattern |
+
+## Architecture
+
+```
+components/
+  ProfileAvatar.tsx       — Crack mascot in circular container
+  StreakCard.tsx           — flame icon, current streak, best streak
+  LeaderboardList.tsx     — section header, ranked rows, pinned user row
+  LeaderboardRow.tsx      — single row (rank, username, tier, XP)
+```
+
+## File Details
+
+### `components/ProfileAvatar.tsx`
+
+Props: `size?: number` (default 80)
+
+- Circular container: `borderRadius: size/2`, border `2.5px solid colors.primary`
+- Background: `colors.surface2`
+- Displays `assets/crack-mascot.png` via `<Image>` filling the circle
+- Later: accept an optional `uri` prop to show custom avatar instead of mascot
+
+### `components/StreakCard.tsx`
+
+No props — reads `streakDays` from `useXpStore`.
+
+- Card: `colors.surface` background, `colors.border` border, `borderRadius: 14`
+- Left side: 🔥 emoji (28px) + streak count (24px bold gold) + "day streak" label
+- Right side: "BEST" label + hardcoded best streak value (e.g. 12 days)
+- Best streak is hardcoded for demo — `useXpStore` doesn't track it yet
+
+### `components/LeaderboardRow.tsx`
+
+Props: `rank: number`, `username: string`, `xp: number`, `tier: string`, `isCurrentUser: boolean`
+
+- Row layout: rank number (28px width) | username (flex) | tier name | XP count
+- Default style: `colors.surface` background, `colors.border` border
+- Current user style: gold-to-purple gradient background (`linear-gradient(135deg, rgba(245,200,66,0.2), rgba(155,109,255,0.25), rgba(107,63,212,0.2))`), `colors.primaryLight` border, username has ⭐ suffix and bold weight
+- Rank #1 gets gold colored rank number, others get `colors.text2`
+
+Note: React Native doesn't support CSS `linear-gradient` on `View`. Implementation uses `expo-linear-gradient` (`LinearGradient` component) as the row background for the current user's row.
+
+### `components/LeaderboardList.tsx`
+
+Props: `currentUsername: string`
+
+- "LEADERBOARD" section label (11px, uppercase, `colors.text3`, letter-spacing 1.5)
+- Reads from `DEMO_LEADERBOARD` in `lib/mockData.ts`, sorted by XP descending
+- Renders rows via `.map()` (no FlatList — CLAUDE.md rule)
+- Each row gets `isCurrentUser={entry.username === currentUsername}`
+- Below the main list: pinned row showing current user's position
+  - Same gradient styling as the highlighted row
+  - "Your position" label below (10px, centered, `colors.text3`)
+  - Separated from list by 8px gap
+
+## Mock Data Update
+
+The existing `DEMO_LEADERBOARD` in `lib/mockData.ts` is sufficient:
+
+```typescript
+export const DEMO_LEADERBOARD = [
+  { username: "AlexChen", xp: 1420, tier: "Scholar" },
+  { username: "SarahM", xp: 1380, tier: "Grinder" },
+  { username: "DemoStudent", xp: 1240, tier: "Grinder" },
+  { username: "JakeW", xp: 1100, tier: "Grinder" },
+  { username: "EmmaL", xp: 890, tier: "Grinder" },
+];
+```
+
+No changes needed — tiers can be derived via `getCurrentTier()` but the mock data already has them as strings, which is fine for the demo.
+
+## Screen Integration (`app/(tabs)/profile.tsx`)
+
+Replace the placeholder section below the divider. Full layout top to bottom:
+
+1. `ProfileAvatar` — centered, 80px
+2. Username text — "DemoStudent" (from `useAuthStore`)
+3. University text — "McGill University"
+4. `RankBadge` variant="shield" (existing from #4)
+5. `XpAnimatedCounter` size="full" (existing from #4)
+6. `XpProgressBar` size="full" (existing from #4)
+7. Divider (existing)
+8. `StreakCard`
+9. `LeaderboardList` with `currentUsername` from auth store
+
+## Dependencies
+
+- `expo-linear-gradient` — needed for the gold-to-purple gradient on user's leaderboard row. Must be added to `package.json`.
+
+## Mockup Reference
+
+Visual mockups saved in `.superpowers/brainstorm/` — see `profile-mockup-v2.html` for the approved layout.

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -66,4 +66,11 @@ export const DEMO_LEADERBOARD = [
   { username: "DemoStudent", xp: 1240, tier: "Grinder" },
   { username: "JakeW", xp: 1100, tier: "Grinder" },
   { username: "EmmaL", xp: 890, tier: "Grinder" },
+  { username: "LiamT", xp: 820, tier: "Grinder" },
+  { username: "MayaR", xp: 740, tier: "Grinder" },
+  { username: "NoahK", xp: 610, tier: "Grinder" },
+  { username: "OliviaP", xp: 530, tier: "Grinder" },
+  { username: "EthanB", xp: 450, tier: "Student" },
+  { username: "SophieW", xp: 380, tier: "Student" },
+  { username: "DanielF", xp: 290, tier: "Student" },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "studyquest-init",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/vector-icons": "^15.1.1",
         "@supabase/supabase-js": "^2.101.1",
         "expo": "~54.0.33",
         "expo-av": "~16.0.8",
         "expo-constants": "~18.0.13",
+        "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-notifications": "~0.32.16",
         "expo-router": "~6.0.23",
@@ -88,7 +90,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2144,6 +2145,17 @@
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
     },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz",
@@ -2923,7 +2935,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -3223,9 +3234,8 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3882,7 +3892,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4429,7 +4438,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4808,7 +4817,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -4887,7 +4895,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -4897,12 +4904,22 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-linking": {
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
       "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -5378,17 +5395,6 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
-      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo/node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -5443,7 +5449,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6855,7 +6860,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8814,7 +8818,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9153,7 +9156,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9189,19 +9191,6 @@
         }
       }
     },
-    "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
@@ -9231,7 +9220,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -9332,7 +9320,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -9358,7 +9345,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -9386,7 +9372,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -9397,7 +9382,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -9560,7 +9544,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9968,12 +9951,6 @@
       "engines": {
         "node": ">=11.0.0"
       }
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -10445,7 +10422,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -10665,7 +10641,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10895,7 +10870,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -11367,7 +11341,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.1.1",
     "@supabase/supabase-js": "^2.101.1",
     "expo": "~54.0.33",
     "expo-av": "~16.0.8",
     "expo-constants": "~18.0.13",
+    "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-notifications": "~0.32.16",
     "expo-router": "~6.0.23",

--- a/store/useStudyStore.ts
+++ b/store/useStudyStore.ts
@@ -6,12 +6,17 @@ interface StudyState {
   mode: "focus" | "deep" | null;
   elapsedSeconds: number;
   currentTopicId: string | null;
+  isOnBreak: boolean;
+  breakSecondsLeft: number;
   startSession: (mode: "focus" | "deep", topicId: string) => void;
   pauseSession: () => void;
   resumeSession: () => void;
   endSession: () => void;
   resetSession: () => void;
   tick: () => void;
+  startBreak: () => void;
+  tickBreak: () => void;
+  endBreak: () => void;
 }
 
 export const useStudyStore = create<StudyState>((set) => ({
@@ -20,12 +25,24 @@ export const useStudyStore = create<StudyState>((set) => ({
   mode: null,
   elapsedSeconds: 0,
   currentTopicId: null,
+  isOnBreak: false,
+  breakSecondsLeft: 0,
   startSession: (mode, topicId) =>
-    set({ isStudying: true, isPaused: false, mode, currentTopicId: topicId, elapsedSeconds: 0 }),
+    set({ isStudying: true, isPaused: false, mode, currentTopicId: topicId, elapsedSeconds: 0, isOnBreak: false, breakSecondsLeft: 0 }),
   pauseSession: () => set({ isPaused: true }),
   resumeSession: () => set({ isPaused: false }),
   endSession: () => set({ isStudying: false, isPaused: false, mode: null, currentTopicId: null }),
   resetSession: () =>
-    set({ isStudying: false, isPaused: false, mode: null, currentTopicId: null, elapsedSeconds: 0 }),
+    set({ isStudying: false, isPaused: false, mode: null, currentTopicId: null, elapsedSeconds: 0, isOnBreak: false, breakSecondsLeft: 0 }),
   tick: () => set((s) => ({ elapsedSeconds: s.elapsedSeconds + 1 })),
+  startBreak: () => set({ isOnBreak: true, isPaused: true, breakSecondsLeft: 300 }),
+  tickBreak: () =>
+    set((s) => {
+      const next = s.breakSecondsLeft - 1;
+      if (next <= 0) {
+        return { isOnBreak: false, breakSecondsLeft: 0 };
+      }
+      return { breakSecondsLeft: next };
+    }),
+  endBreak: () => set({ isOnBreak: false, breakSecondsLeft: 0, isPaused: false }),
 }));

--- a/store/useStudyStore.ts
+++ b/store/useStudyStore.ts
@@ -1,13 +1,21 @@
 import { create } from "zustand";
 
+const DEEP_SESSION_DURATION = 2.5 * 60 * 60; // 2h30 in seconds
+const BREAK_INTERVAL = 30 * 60; // 30 min in seconds
+const BREAK_DURATION = 5 * 60; // 5 min in seconds
+
 interface StudyState {
   isStudying: boolean;
   isPaused: boolean;
   mode: "focus" | "deep" | null;
   elapsedSeconds: number;
   currentTopicId: string | null;
+  // Deep Mode specific
+  deepSecondsLeft: number;
+  nextBreakIn: number;
   isOnBreak: boolean;
   breakSecondsLeft: number;
+  // Actions
   startSession: (mode: "focus" | "deep", topicId: string) => void;
   pauseSession: () => void;
   resumeSession: () => void;
@@ -25,17 +33,61 @@ export const useStudyStore = create<StudyState>((set) => ({
   mode: null,
   elapsedSeconds: 0,
   currentTopicId: null,
+  deepSecondsLeft: 0,
+  nextBreakIn: 0,
   isOnBreak: false,
   breakSecondsLeft: 0,
   startSession: (mode, topicId) =>
-    set({ isStudying: true, isPaused: false, mode, currentTopicId: topicId, elapsedSeconds: 0, isOnBreak: false, breakSecondsLeft: 0 }),
+    set({
+      isStudying: true,
+      isPaused: false,
+      mode,
+      currentTopicId: topicId,
+      elapsedSeconds: 0,
+      isOnBreak: false,
+      breakSecondsLeft: 0,
+      deepSecondsLeft: mode === "deep" ? DEEP_SESSION_DURATION : 0,
+      nextBreakIn: mode === "deep" ? BREAK_INTERVAL : 0,
+    }),
   pauseSession: () => set({ isPaused: true }),
   resumeSession: () => set({ isPaused: false }),
   endSession: () => set({ isStudying: false, isPaused: false, mode: null, currentTopicId: null }),
   resetSession: () =>
-    set({ isStudying: false, isPaused: false, mode: null, currentTopicId: null, elapsedSeconds: 0, isOnBreak: false, breakSecondsLeft: 0 }),
-  tick: () => set((s) => ({ elapsedSeconds: s.elapsedSeconds + 1 })),
-  startBreak: () => set({ isOnBreak: true, isPaused: true, breakSecondsLeft: 300 }),
+    set({
+      isStudying: false, isPaused: false, mode: null, currentTopicId: null,
+      elapsedSeconds: 0, isOnBreak: false, breakSecondsLeft: 0,
+      deepSecondsLeft: 0, nextBreakIn: 0,
+    }),
+  tick: () =>
+    set((s) => {
+      if (s.mode === "deep") {
+        const newDeep = s.deepSecondsLeft - 1;
+        const newBreakIn = s.nextBreakIn - 1;
+        // Session complete
+        if (newDeep <= 0) {
+          return { deepSecondsLeft: 0, nextBreakIn: 0, isStudying: false };
+        }
+        // Time for a break
+        if (newBreakIn <= 0) {
+          return {
+            deepSecondsLeft: newDeep,
+            nextBreakIn: 0,
+            isOnBreak: true,
+            isPaused: true,
+            breakSecondsLeft: BREAK_DURATION,
+            elapsedSeconds: s.elapsedSeconds + 1,
+          };
+        }
+        return {
+          deepSecondsLeft: newDeep,
+          nextBreakIn: newBreakIn,
+          elapsedSeconds: s.elapsedSeconds + 1,
+        };
+      }
+      // Focus mode — count up
+      return { elapsedSeconds: s.elapsedSeconds + 1 };
+    }),
+  startBreak: () => set({ isOnBreak: true, isPaused: true, breakSecondsLeft: BREAK_DURATION }),
   tickBreak: () =>
     set((s) => {
       const next = s.breakSecondsLeft - 1;
@@ -44,5 +96,5 @@ export const useStudyStore = create<StudyState>((set) => ({
       }
       return { breakSecondsLeft: next };
     }),
-  endBreak: () => set({ isOnBreak: false, breakSecondsLeft: 0, isPaused: false }),
+  endBreak: () => set({ isOnBreak: false, breakSecondsLeft: 0, isPaused: false, nextBreakIn: BREAK_INTERVAL }),
 }));


### PR DESCRIPTION
## Summary
- ZigzagPath: rewrite with absolute positioning — proper diagonal lines connecting node centers, lines stop at circle borders, dynamic scaling to fit card
- FlashcardModal: re-roll question on every open, replace low-opacity answer with grey placeholder bars (fully hidden until tap), empty state when no questions
- CourseCard: remove course code, pin exam badge far right, filter past exams, fix "1 day/days" grammar
- Add .superpowers/ and .claude/ to .gitignore

## Test Plan
- [ ] Zigzag lines connect node-to-node diagonally, no overflow, no overlap into numbers
- [ ] Flashcard shows different question each open
- [ ] Answer fully hidden until tapped (grey bars)
- [ ] No course code on cards
- [ ] Exam badge pinned far right
- [ ] Past exams filtered from countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)