### PR TITLE
docs: rewrite README in presentation style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,237 @@
-# StudyQuest
+<h1 align="center">StudyQuest</h1>
 
-**Turn university life into a game worth playing.**
+<p align="center">
+  <strong>Turn university life into a game worth playing.</strong><br/>
+  A mobile-first, MMORPG-styled academic engagement platform for students who are already gamers — the gameplay just happens to make them better students.
+</p>
 
-StudyQuest is a mobile-first academic engagement platform that transforms studying, attending class, and collaborating into a gamified experience with real social currency and real rewards. Built for students who are already gamers — the gameplay just happens to make them better students.
+<p align="center">
+  <img src="https://img.shields.io/badge/React%20Native-0.81-61DAFB?style=flat&logo=react&logoColor=white" />
+  <img src="https://img.shields.io/badge/Expo-SDK%2054-000020?style=flat&logo=expo&logoColor=white" />
+  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white" />
+  <img src="https://img.shields.io/badge/Babylon.js-3D-BB4B44?style=flat&logo=babylondotjs&logoColor=white" />
+  <img src="https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white" />
+  <img src="https://img.shields.io/badge/Claude-AI-D97757?style=flat" />
+  <img src="https://img.shields.io/badge/Phase%201-McGill-red?style=flat" />
+</p>
 
-## Why StudyQuest?
+<p align="center">
+  <img src="assets/crack-mascot.png" width="180" alt="Crack — the StudyQuest mascot" />
+</p>
 
-Students fight billion-dollar attention algorithms with willpower alone. Academic effort is invisible until exam day. Study resources are scattered across group chats and random PDFs. StudyQuest fixes all three.
+<p align="center"><em>Meet Crack — a purple slime in a graduation cap. Your study companion.</em></p>
 
-## Core Pillars
+---
 
-### Study Mode
-Distraction-blocking study sessions with AI-assisted learning. Focus Mode uses quiz checkpoints as intelligent friction. Deep Mode locks down the device entirely. Both reward sustained effort with XP.
+## What is StudyQuest?
 
-### The Rank
-A social reputation system powered by verified academic behavior — class attendance, study time, resource contributions, and collaboration. Rank tiers (Student → Legend) reset each semester. Leaderboards by course, campus, and friend group.
+StudyQuest is a mobile app that treats your semester like a game campaign. Every course is a map. Every exam is a boss. Every lecture, study session, and note upload earns XP that feeds a visible social rank — **Student → Grinder → Scholar → Veteran → Elite → Legend** — that resets every semester so nobody coasts on old glory.
 
-### The Commons
-A course-specific knowledge layer. Upload lecture notes, past exams, and study guides. Form study groups. Discover campus events. Top contributors earn XP and social credibility.
+It is not a productivity app with a points skin on top. It is designed from the ground up as *a game*, so that the gameplay loop is what keeps students coming back — and the side effect is that they study more, attend class more, and share resources more.
 
-## Key Features (MVP)
+---
 
-- **Course Setup** — Manual input of courses, exams, topics, and deadlines
-- **Progress Map** — Visual timeline with Readiness Scores per exam
-- **Focus Mode** — Timer-based study with quiz checkpoints on distraction
-- **Deep Mode** — OS-level distraction blocking (iOS Screen Time / Android Accessibility)
-- **Flashcard Engine** — Auto-generated from uploaded notes with spaced repetition
-- **Assignment Breakdown** — AI-powered day-by-day task plans via Claude API
-- **XP & Rank System** — Earn XP for attendance, study sessions, contributions
-- **Course Leaderboard** — Compete with classmates on effort, not grades
-- **Resource Commons** — Upload/download course materials, tagged by topic
+## Why we built it
 
-## Tech Stack
+Three things are broken for university students right now:
 
-| Layer | Technology |
-|-------|-----------|
-| Mobile | React Native + Expo (SDK 51+) |
-| Navigation | Expo Router (file-based routing) |
-| 3D Map | Babylon.js (@babylonjs/react-native) |
-| Styling | NativeWind (Tailwind for React Native) |
-| Backend / DB | Supabase (PostgreSQL + Auth + Storage) |
-| Edge Functions | Supabase Edge Functions (Deno runtime) |
-| AI | Claude API (Anthropic) — tutoring, flashcard gen, assignment breakdown |
-| Notifications | Expo Notifications + Supabase triggers |
-| State Management | Zustand |
+1. **Distraction is engineered.** TikTok and Instagram spend billions optimizing attention capture. A student with a phone and willpower is in a fight they cannot win alone.
+2. **Effort is invisible.** Attending every class and grinding the readings produces no visible signal until grades arrive weeks later. There's no feedback loop, so motivation collapses.
+3. **Resources are fragmented.** Lecture notes, past exams, and study tips live in scattered group chats and random Google Drives. Course-wide knowledge never pools.
 
-## Target
+StudyQuest fixes all three with one mechanic: turn the behavior you want into a game, and make the score social.
 
-**Phase 1:** McGill University students
-**Phase 2:** University portal integration, study groups, attendance tracking, AI Tutor
-**Phase 3:** Teacher dashboard, multi-university expansion
+---
 
-## Project Structure
+## The three pillars
+
+### 🎯 Study Mode — distraction-blocking, AI-assisted focus
+
+**Focus Mode (light):** Timer-based session. When the student tries to leave to scroll, a quiz checkpoint fires — one multiple-choice question drawn from their actual course material. Correct = 5-minute break. Incorrect = redirected back with exam countdown and Readiness Score.
+
+**Deep Mode (locked):** Full OS-level distraction block via iOS Screen Time and Android Accessibility Service. Exits cost rank points unless earned through a quiz.
+
+**AI Tutor:** Context-aware chat powered by Claude. Pre-loaded with course material, current topic, and exam timeline. Pushes back, asks follow-ups, prompts students to explain concepts — closer to a study partner than a homework cheat.
+
+### 🏆 The Rank — a reputation system for academic effort
+
+Effort becomes visible. XP flows in for the stuff that actually moves the needle:
+
+| Action | XP |
+|---|---|
+| Attending a class (verified) | **+50** |
+| 20+ min study session | **+30** |
+| Quiz checkpoint correct | **+10** |
+| Topic mastery check passed | **+40** |
+| Uploading a resource | **+25** (plus 5/download from peers) |
+| Joining + completing a study group | **+35** |
+| Asking a question in class (prof-verified) | **+60** |
+| Assignment submitted before deadline | **+20** |
+| 7-day study streak | **2× multiplier** |
+
+Leaderboards per course, per campus, and per friend group.
+
+### 📚 The Commons — a course-specific knowledge layer
+
+Students upload lecture notes, past exams, and study guides. Everything is tagged by course and topic. Top contributors earn XP *and* social credibility. Form study groups. Discover campus events. The pool of class knowledge stops leaking into random group chats.
+
+---
+
+## How it works
 
 ```
-cracked-quest/
-├── PRD.md                  # Product Requirements Document
-├── TECH_SPEC.md            # Technical Specification
-├── README.md               # This file
-├── app/                    # Expo Router screens
-│   ├── (auth)/             # Login, signup, onboarding
-│   ├── (tabs)/             # Main tab navigator
-│   │   ├── index.tsx       # Progress Map (home)
-│   │   ├── study.tsx       # Study Mode
-│   │   ├── quests.tsx      # Assignment Breakdown
-│   │   ├── commons.tsx     # Resource sharing
-│   │   └── profile.tsx     # Rank + leaderboard
-│   └── map/
-│       └── [courseId].tsx   # Per-course 3D MMORPG map
-├── components/             # Reusable UI components
-├── lib/                    # Supabase client, API helpers
-├── store/                  # Zustand state stores
-├── supabase/
-│   └── functions/          # Edge Functions (Deno)
-│       ├── breakdown/      # Assignment AI breakdown
-│       ├── quiz-gen/       # Quiz question generation
-│       └── flashcards/     # Flashcard generation
-└── assets/                 # 3D models, fonts, images
+   ┌──────────────────────┐
+   │  React Native + Expo │   Mobile client (iOS/Android)
+   │  NativeWind · Zustand│
+   │  Expo Router v6      │
+   └──────────┬───────────┘
+              │
+              │  Authenticated requests
+              ▼
+   ┌──────────────────────┐
+   │      Supabase        │   Postgres · Auth · Storage · Realtime
+   │   (single backend)   │
+   └─────┬──────────┬─────┘
+         │          │
+         │          │  AI calls routed server-side only
+         │          ▼
+         │  ┌────────────────────┐
+         │  │  Edge Functions    │   Deno runtime
+         │  │  • breakdown       │   Assignment → day-by-day plan
+         │  │  • quiz-gen        │   Lecture material → checkpoints
+         │  │  • flashcards      │   Notes → spaced-repetition deck
+         │  │  • award_xp        │   Secure XP writer
+         │  └─────────┬──────────┘
+         │            │
+         │            ▼
+         │    ┌───────────────┐
+         │    │  Claude API   │   claude-sonnet-4
+         │    │  (Anthropic)  │
+         │    └───────────────┘
+         │
+         ▼
+   ┌──────────────────────┐
+   │  Babylon.js native   │   3D MMORPG-style progression map
+   │  (@babylonjs/react-  │   per course
+   │  native)             │
+   └──────────────────────┘
 ```
 
-## Getting Started
+**Architecture rules we do not break:**
+
+- **The client never calls Claude directly.** Every AI call is brokered by a Supabase Edge Function so the API key never leaves the server.
+- **XP is server-awarded.** A dedicated `award_xp` Edge Function is the only path that can mutate XP — no client can forge progression.
+- **The 3D map requires native modules.** Babylon.js on RN means prebuild is required; the app will not render the map in Expo Go.
+
+---
+
+## Tech stack
+
+| Layer | Tool |
+|---|---|
+| Mobile runtime | React Native 0.81 + Expo SDK 54 (New Architecture enabled) |
+| Language | TypeScript |
+| Navigation | Expo Router v6 (file-based) |
+| Styling | NativeWind v4 (Tailwind for RN) |
+| State | Zustand v5 |
+| 3D progression map | Babylon.js via `@babylonjs/react-native` |
+| Backend + Auth + DB + Storage | Supabase (Postgres) |
+| AI gateway | Supabase Edge Functions (Deno) → Claude (`claude-sonnet-4-20250514`) |
+| Notifications | Expo Notifications |
+
+---
+
+## Design system
+
+Dark, neon, game-first. Feels like opening Clash Royale, not a planner.
+
+| Token | Value |
+|---|---|
+| Background | `#0C0C10` |
+| Surface | `#141418` / `#1C1C22` |
+| Primary (purple) | `#9B6DFF` |
+| Gold | `#F5C842` |
+| Success | `#4EFFB4` |
+| Danger | `#FF5757` |
+| Display font | Sora |
+| Body font | DM Sans |
+| Buttons | Pill-shaped, uppercase, 0.8 letter-spacing |
+
+Full tokens in `lib/theme.ts`. Mascot and visual language in `assets/`.
+
+---
+
+## Getting started
 
 ```bash
-# Clone the repo
+# Clone
 git clone https://github.com/theaboy/cracked-quest.git
 cd cracked-quest
 
-# Install dependencies
+# Install
 npm install
 
-# Start Expo dev server
+# Dev (no 3D map — quick iteration in Expo Go)
 npx expo start
 
-# For 3D map (requires native modules)
+# Dev with 3D map (requires native build)
 npx expo prebuild
-npx expo run:ios    # or run:android
+npx expo run:ios          # or: npx expo run:android
+
+# Type-check
+npx tsc --noEmit
 ```
+
+**Supabase Edge Functions:**
+
+```bash
+supabase functions deploy breakdown
+supabase functions deploy quiz-gen
+supabase functions deploy flashcards
+supabase functions deploy award_xp
+```
+
+You'll need a Supabase project with the schema in `supabase/` applied and `ANTHROPIC_API_KEY` configured as a Function secret.
+
+---
+
+## Project structure
+
+```
+app/                    Expo Router screens
+  (auth)/               Login, signup, onboarding
+  (tabs)/               Main tab nav
+    index.tsx           Progress Map (home)
+    study.tsx           Study Mode
+    quests.tsx          Assignment breakdown
+    commons.tsx         Resource sharing
+    profile.tsx         Rank + leaderboard
+  map/[courseId].tsx    Per-course 3D MMORPG map
+components/             Reusable UI
+lib/                    Supabase client, theme, API helpers
+store/                  Zustand stores
+supabase/functions/     Edge Functions (breakdown, quiz-gen, flashcards, award_xp)
+assets/                 Mascot, 3D models, fonts, images
+PRD.md                  Full product requirements
+TECH_SPEC.md            Architecture, schema, Edge Function contracts
+CLAUDE.md               Project memory + conventions for AI contributors
+```
+
+---
+
+## Roadmap
+
+- **Phase 1 (now)** — McGill students. Manual course setup, core gameplay loop, AI tutor, Commons MVP.
+- **Phase 2** — OAuth into university portals, verified attendance, study-group matchmaking, richer AI tutor flows.
+- **Phase 3** — Teacher dashboards, multi-university expansion, cross-campus leaderboards.
+
+---
+
+## Team
+
+Built at McGill by [theaboy](https://github.com/theaboy) and [William](https://deathnote21306.github.io/).
+
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat&logo=typescript&logoColor=white" />
   <img src="https://img.shields.io/badge/Babylon.js-3D-BB4B44?style=flat&logo=babylondotjs&logoColor=white" />
   <img src="https://img.shields.io/badge/Supabase-3ECF8E?style=flat&logo=supabase&logoColor=white" />
-  <img src="https://img.shields.io/badge/Claude-AI-D97757?style=flat" />
+  <img src="https://img.shields.io/badge/LLM-AI-9B6DFF?style=flat" />
   <img src="https://img.shields.io/badge/Phase%201-McGill-red?style=flat" />
 </p>
 
@@ -51,7 +51,7 @@ StudyQuest fixes all three with one mechanic: turn the behavior you want into a 
 
 **Deep Mode (locked):** Full OS-level distraction block via iOS Screen Time and Android Accessibility Service. Exits cost rank points unless earned through a quiz.
 
-**AI Tutor:** Context-aware chat powered by Claude. Pre-loaded with course material, current topic, and exam timeline. Pushes back, asks follow-ups, prompts students to explain concepts — closer to a study partner than a homework cheat.
+**AI Tutor:** Context-aware chat powered by an LLM. Pre-loaded with course material, current topic, and exam timeline. Pushes back, asks follow-ups, prompts students to explain concepts — closer to a study partner than a homework cheat.
 
 ### 🏆 The Rank — a reputation system for academic effort
 
@@ -105,8 +105,9 @@ Students upload lecture notes, past exams, and study guides. Everything is tagge
          │            │
          │            ▼
          │    ┌───────────────┐
-         │    │  Claude API   │   claude-sonnet-4
-         │    │  (Anthropic)  │
+         │    │   LLM API     │   reasoning-grade model
+         │    │   (server-    │   called only from the
+         │    │    side only) │   Edge Function tier
          │    └───────────────┘
          │
          ▼
@@ -119,7 +120,7 @@ Students upload lecture notes, past exams, and study guides. Everything is tagge
 
 **Architecture rules we do not break:**
 
-- **The client never calls Claude directly.** Every AI call is brokered by a Supabase Edge Function so the API key never leaves the server.
+- **The client never calls the LLM directly.** Every AI call is brokered by a Supabase Edge Function so the API key never leaves the server.
 - **XP is server-awarded.** A dedicated `award_xp` Edge Function is the only path that can mutate XP — no client can forge progression.
 - **The 3D map requires native modules.** Babylon.js on RN means prebuild is required; the app will not render the map in Expo Go.
 
@@ -136,7 +137,7 @@ Students upload lecture notes, past exams, and study guides. Everything is tagge
 | State | Zustand v5 |
 | 3D progression map | Babylon.js via `@babylonjs/react-native` |
 | Backend + Auth + DB + Storage | Supabase (Postgres) |
-| AI gateway | Supabase Edge Functions (Deno) → Claude (`claude-sonnet-4-20250514`) |
+| AI gateway | Supabase Edge Functions (Deno) → hosted LLM (swappable provider) |
 | Notifications | Expo Notifications |
 
 ---
@@ -191,7 +192,7 @@ supabase functions deploy flashcards
 supabase functions deploy award_xp
 ```
 
-You'll need a Supabase project with the schema in `supabase/` applied and `ANTHROPIC_API_KEY` configured as a Function secret.
+You'll need a Supabase project with the schema in `supabase/` applied and an LLM provider API key configured as a Function secret.
 
 ---
 
@@ -214,7 +215,7 @@ supabase/functions/     Edge Functions (breakdown, quiz-gen, flashcards, award_x
 assets/                 Mascot, 3D models, fonts, images
 PRD.md                  Full product requirements
 TECH_SPEC.md            Architecture, schema, Edge Function contracts
-CLAUDE.md               Project memory + conventions for AI contributors
+CLAUDE.md               Internal dev-tool memory file (not user-facing)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Leads with mascot + one-line vision, frames the three pillars (Study Mode, The Rank, The Commons) with concrete XP numbers pulled from the PRD.
- Adds an ASCII architecture diagram that makes the non-negotiables legible at a glance: no client-side Claude calls, XP awarded server-side only, prebuild required for the Babylon map.
- Adds a design-system token table (pulled from CLAUDE.md / lib/theme.ts) and a phase 1/2/3 roadmap.
- Keeps full getting-started, project layout, and Edge Function deploy commands.

Existing README was solid but read more like a spec. This version is written to be the first thing a visitor — investor, teammate, recruiter — reads before deciding to click further.

## Test plan
- [ ] Preview README on GitHub and verify badge row + mascot image render
- [ ] Verify all internal asset paths (\`assets/crack-mascot.png\`) resolve
- [ ] @theaboy review